### PR TITLE
feat(signup): show support code FLN in criminal-name error message

### DIFF
--- a/cgmembers/rcredits/cg-strings.inc
+++ b/cgmembers/rcredits/cg-strings.inc
@@ -460,6 +460,7 @@ EOF
   'email plus' => t('If you want to use the same email address for this account, add a plus sign (+) and an arbitrary tag to the local part, for example "%emailTagged".'), // used in user.module
   'forgot password' => t('If you just forgot the password to the other account, <%a>click here</a> to request a new password.'), // used in user.module
   'bad name' => t('That is not a plausible name.'),
+  'code FLN' => t('There is a problem with your account application. Please contact our support staff at %CGF_PHONE. Tell them code FLN.'),
   'bad phone' => t('That is not a proper phone number.'),
   'not your account' => t('That is not your account ID.'),
   'bad account number' => t('Your bank account number must be 3-17 digits long.'),

--- a/cgmembers/rcredits/forms/signup.inc
+++ b/cgmembers/rcredits/forms/signup.inc
@@ -101,7 +101,7 @@ function formSignup_validate($form, &$sta) {
   $err = u\badName($fullName); if ($err) return err($err, ['field' => 'fullName'], 'fullName');
   if (r\isCriminal($fullName, FALSE)) {
     r\tellAdmin(t('New potential member flagged as criminal'), $sta['input']);
-    return softErr(t('There is a problem with your account application. Please contact our support staff at %CGF_PHONE.'));
+    return softErr(t('code FLN'));
   }
   $fullName = u\normalizeCase($fullName);
 

--- a/cgmembers/rcredits/forms/signup.inc
+++ b/cgmembers/rcredits/forms/signup.inc
@@ -101,7 +101,7 @@ function formSignup_validate($form, &$sta) {
   $err = u\badName($fullName); if ($err) return err($err, ['field' => 'fullName'], 'fullName');
   if (r\isCriminal($fullName, FALSE)) {
     r\tellAdmin(t('New potential member flagged as criminal'), $sta['input']);
-    return softErr(t('code FLN'));
+    return softErr(tr('code FLN'));
   }
   $fullName = u\normalizeCase($fullName);
 

--- a/cgmembers/rcredits/rweb/features/signup.feature
+++ b/cgmembers/rcredits/rweb/features/signup.feature
@@ -312,3 +312,12 @@ Scenario: A member registers again
   Then we say "error": "duplicate email|forgot password" with subs:
   | a                                          |*
   | a href="settings/password/a%40example.com" |
+
+Scenario: A member registers with criminal name
+  Given these "ofac":
+  | nm    | co |*
+  | chris | 0  |
+  When member "?" confirms form "signup" with values:
+  | fullName | email | phone        |  zip  | acctType     | cq | ca |*
+  | Chris    | c@    | 413-253-0000 | 01002 | %CO_PERSONAL | 37 | 74 |
+  Then we say "error": "code FLN"


### PR DESCRIPTION
## Summary
- Append "Tell them code FLN." to the criminal-name signup error so support staff can identify the cause when users contact them (the underlying OFAC match can't be disclosed to the user).
- Adds `'code FLN'` translation key in [cg-strings.inc](cgmembers/rcredits/cg-strings.inc), following the existing key-based pattern of `'bad email'`, `'bad phone'`, etc.
