### PR TITLE
fix: PHP 8.x compatibility for bootstrap

### DIFF
--- a/cgmembers/includes/errors.inc
+++ b/cgmembers/includes/errors.inc
@@ -19,7 +19,7 @@ include_once R_ROOT . '/cg-util.inc';
  * @ingroup logging_severity_levels
  */
 function drupal_error_levels() {
-  return [
+  $levels = [
     E_ERROR => ['Error', WATCHDOG_ERROR],
     E_WARNING => ['Warning', WATCHDOG_WARNING],
     E_PARSE => ['Parse error', WATCHDOG_ERROR],
@@ -33,9 +33,10 @@ function drupal_error_levels() {
     E_USER_NOTICE => ['User notice', WATCHDOG_NOTICE],
     E_DEPRECATED => ['Deprecated function', WATCHDOG_DEPRECATED],
     E_USER_DEPRECATED => ['User deprecated function', WATCHDOG_USER_DEPRECATED],
-    E_STRICT => ['Strict warning', WATCHDOG_DEBUG],
     E_RECOVERABLE_ERROR => ['Recoverable fatal error', WATCHDOG_ERROR],
   ];
+  if (defined('E_STRICT')) $levels[E_STRICT] = ['Strict warning', WATCHDOG_DEBUG]; // E_STRICT removed in PHP 8.4
+  return $levels;
 }
 
 /**
@@ -63,6 +64,7 @@ function handleError($level, $msg, $file, $line, $trace = NULL) {
     foreach ($ignore as $k) if (strpos($msg, $k) !== FALSE) return; // work around flaws in fopen and file_get_contents
   }
   if ($severity == WATCHDOG_DEBUG) return;
+  if ($severity == WATCHDOG_DEPRECATED or $severity == WATCHDOG_USER_DEPRECATED) return; // PHP 8.4+ deprecations should not crash the bootstrap
 ///  debug($context); echo pr($context); // handy when debugging
 
   $nasty = ($severity < WATCHDOG_WARNING);

--- a/cgmembers/rcredits/boot.inc
+++ b/cgmembers/rcredits/boot.inc
@@ -5,8 +5,10 @@
  * Also used by /do.php, for no-sign-in database changes
  */
 
+error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED); // suppress PHP 8.4+ deprecations until codebase migrates off PDO::MYSQL_ATTR_* and implicit nullable params
+
 strip($_POST); strip($_GET); // No HTML input EVER (unless encoded in a way we expect)
- 
+
 global $base_url, $base_path, $base_root;
 global $databases, $drupal_hash_salt;
 global $cookie_domain, $is_https, $base_secure_url, $base_insecure_url;
@@ -36,10 +38,10 @@ ini_set('session.use_trans_sid', '0');
 ini_set('session.cache_limiter', ''); // Don't send HTTP headers using PHP's session handler.
 ini_set('session.cookie_httponly', '1'); // Use httponly session cookies.
 
-ini_set('error_reporting', E_ALL);
+ini_set('error_reporting', E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED); // mirror the early error_reporting() call
 ini_set('max_execution_time', isDEV ? 0 : (4 * 60)); // don't ever timeout processing when developing
-ini_set('session.gc_probability', 1); // garbage collection this fraction of the time on startup (numerator)
-ini_set('session.gc_divisor', 0); // (denominator) - disable random garbage collection (do it in cron instead)
+ini_set('session.gc_probability', 0); // disable random garbage collection (do it in cron instead) - PHP 8 disallows gc_divisor=0
+ini_set('session.gc_divisor', 100);
 define('SESSION_LIFE', (nni($_COOKIE, 'pw2') or nni($_POST, 'pw2')) ? (12 * HOUR_SECS) : (24 * MIN_SECS)); // standard 24 mins (more for admin)
 //define('SESSION_LIFE', (nni($_COOKIE, 'pw2') or nni($_POST, 'pw2')) ? (5) : (2 * MIN_SECS)); // for testing
 ini_set('session.gc_maxlifetime', SESSION_LIFE); // session timeout (and garbage collection happens)


### PR DESCRIPTION
## Summary

Three blockers were preventing the codebase from booting on PHP 8.x:

1. **`session.gc_divisor = 0`** — PHP 8 disallows `gc_divisor=0`; intent ("disable random GC") now expressed as `gc_probability=0` with `gc_divisor=100`.
2. **`E_STRICT` reference** — removed as a constant in PHP 8.4. The `drupal_error_levels()` map now adds the entry conditionally via `defined('E_STRICT')`.
3. **Deprecation noise crashes the bootstrap** — PHP 8.4+ adds many deprecations (`PDO::MYSQL_ATTR_INIT_COMMAND`, `PDO::MYSQL_ATTR_USE_BUFFERED_QUERY`, implicit nullable params in `common.inc`). The custom `handleError` `die()`s on deprecation severity. Fix is two-part:
   - Suppress `E_DEPRECATED` / `E_USER_DEPRECATED` via `error_reporting()` early in `boot.inc` so PHP doesn't pass them to the handler at all.
   - Make `handleError` return early when severity is deprecated, as a defensive backstop.

## Verification

- Bootstrap no longer crashes on PHP 8.5 (Homebrew default).
- Server starts, MariaDB connection establishes, bootstrap proceeds past `_drupal_bootstrap_variables()`.
- A separate, unrelated test-data issue (`array_combine` size mismatch in `makeTestAccounts` due to missing `cgf_uid` variable in the seeded dev DB) blocks running the in-browser test menu, but that's outside the scope of PHP version compat.

## What's NOT in scope

This PR doesn't migrate the codebase off the actually-deprecated APIs:
- `PDO::MYSQL_ATTR_INIT_COMMAND` → `\Pdo\Mysql::ATTR_INIT_COMMAND` (deprecated since 8.4)
- `PDO::MYSQL_ATTR_USE_BUFFERED_QUERY` → `\Pdo\Mysql::ATTR_USE_BUFFERED_QUERY`
- Implicit nullable parameters in `common.inc` (and likely elsewhere)

Those are tracked deprecations to address before any future PHP version that *removes* them. Suppressing them now lets us run on PHP 8.x without changing every call site.

## Test plan

- [ ] CI / staging — confirm existing test suite still passes (deprecation suppression shouldn't change behavior, only output)
- [ ] Local — `php -S 127.0.0.1:8000 index.php` from `cgmembers/` boots without dying on `gc_divisor` or deprecations