### PR TITLE
feat(sso): /cgpay-sso endpoint for SvelteKit cgpay POC handoff

### DIFF
--- a/cgmembers/rcredits/cg-menu.inc
+++ b/cgmembers/rcredits/cg-menu.inc
@@ -247,6 +247,7 @@ function menu($submenu = '') {
     'pos' => ['call', 'POS', '1', ANY, 'pos'], // called from the CGPay app
     'ajax' => ['call', 'AJAX', '1', ANY, 'ajax'], // called from our JS scripts
     'api' => ['call', 'API', '1', ANY, 'api'],
+    'cgpay-sso' => ['call', 'CGPay SSO', '', ANY, 'cgpaySso'], // server-to-server: SvelteKit cgpay POC handing off a verified login to PHP
     'cc' => ['call', 'Credit Card Donation', 'Pay 1', ANY],
     'donate-fbo' => ['call', t('Donate'), 'Pay 1', ANY], // deprecated (use donate instead), but still used by Kibilio as of 11/22/2021
   );

--- a/cgmembers/rcredits/defs.inc
+++ b/cgmembers/rcredits/defs.inc
@@ -69,6 +69,7 @@ define('STRIPE_PUBLIC', config('stripePublic'));
 define('STRIPE_SECRET', config('stripeSecret'));
 define('QBO_CREDS', config('qboCreds'));
 define('CLICKUP_CREDS', config('clickupCreds'));
+define('CGPAY_SSO_SECRET', config('cgpaySsoSecret', '')); // shared secret for the SvelteKit cgpay POC /cgpay-sso handoff; empty disables the endpoint
 
 $configRay = (array) config('db'); // now look at just the database config array
 foreach (explode(' ', 'name driver host port user pass salt word encryption') as $k) ${"db_$k"} = config($k);

--- a/cgmembers/rcredits/forms/cgpaysso.inc
+++ b/cgmembers/rcredits/forms/cgpaysso.inc
@@ -2,6 +2,7 @@
 namespace CG\Web;
 use CG as r;
 use CG\Db as db;
+use CG\Util as u;
 
 /**
  * @file
@@ -77,6 +78,25 @@ function cgpaySso() {
   // HTTPS-only sites.
   $cookieVal = session_id();
 
+  // Create a fresh `box-<QID>` device record + cookie. Acct::boxId() normally
+  // does this on a web signin, but its web-channel path reads the existing
+  // device code from $_COOKIE — which is empty on this server-to-server call.
+  // Inline the new-code path: generate a code, write the r_boxes row, return
+  // the cookie name and value so SvelteKit can forward it scoped to the shared
+  // parent domain alongside the SSESS cookie. Without this, downstream PHP
+  // features that look the device up in r_boxes don't recognise it.
+  $boxName = 'box-' . $a->mainQid;
+  $boxValue = u\code();
+  $boxnum = (db\get('MAX(boxnum)', 'r_boxes', ['uid' => $uid]) ?: 0) + 1;
+  db\insert('r_boxes', [
+    'uid' => $uid,
+    'code' => $boxValue,
+    'boxnum' => $boxnum,
+    'created' => now(),
+    'access' => now(),
+    'channel' => TX_WEB,
+  ]);
+
   // Menu categories for this user. Permission rules live in PHP (cg-menu.inc);
   // here we just expose top-level categories the cgpay dashboard renders as links.
   $menu = ['Dashboard', 'History', 'Community', 'Settings'];
@@ -84,9 +104,11 @@ function cgpaySso() {
   if ($a->can(B_ADMIN)) $menu[] = 'Admin';
 
   return exitJson([
-    'cookieName' => session_name(),
-    'sid'        => $cookieVal,
-    'ssid'       => $cookieVal,
-    'menu'       => $menu,
+    'cookieName'      => session_name(),
+    'sid'             => $cookieVal,
+    'ssid'            => $cookieVal,
+    'menu'            => $menu,
+    'boxCookieName'   => $boxName,
+    'boxCookieValue'  => $boxValue,
   ], X_OK);
 }

--- a/cgmembers/rcredits/forms/cgpaysso.inc
+++ b/cgmembers/rcredits/forms/cgpaysso.inc
@@ -51,23 +51,16 @@ function cgpaySso() {
   if (!$a) return exitJust(X_NOTFOUND);
   if (!$a->ok) return exitJust(X_FORBIDDEN);
 
-  // Fresh session IDs — distinct from the (ephemeral) session of THIS request.
-  $sid = drupal_random_key();
-  $ssid = drupal_random_key();
+  // Promote this request to the target user. setAcct() is what the regular
+  // signin form runs after a verified password (see forms/signin.inc). It
+  // updates the global $user, populates $_SESSION, and lets Drupal's
+  // _drupal_session_write() persist a real session row at end of request.
+  r\setAcct($uid, []);
 
-  // Direct INSERT — the codebase's db\insert() helper expects an 'id' primary-key
-  // column that this table doesn't have (sessions uses sid/ssid as the keys).
-  $row = [
-    'uid' => $uid,
-    'acct' => $uid,              // viewing own account
-    'sid' => $sid,
-    'ssid' => $ssid,
-    'hostname' => ip_address(),
-    'timestamp' => REQUEST_TIME,
-    'cache' => 0,
-    'session' => '',             // Drupal hydrates on the user's next request
-  ];
-  db\q('INSERT INTO sessions SET uid=:uid, acct=:acct, sid=:sid, ssid=:ssid, hostname=:hostname, timestamp=:timestamp, cache=:cache, session=:session', $row);
+  // session_id() now holds the value Drupal will write to sessions.ssid (and
+  // sessions.sid, since the site is HTTPS-only). That's what the browser will
+  // send back to the PHP host as the SSESS cookie.
+  $cookieVal = session_id();
 
   // Menu categories for this user. Permission rules live in PHP (cg-menu.inc);
   // here we just expose top-level categories the cgpay dashboard renders as links.
@@ -77,8 +70,8 @@ function cgpaySso() {
 
   return exitJson([
     'cookieName' => session_name(),
-    'sid'        => $sid,
-    'ssid'       => $ssid,
+    'sid'        => $cookieVal,
+    'ssid'       => $cookieVal,
     'menu'       => $menu,
   ], X_OK);
 }

--- a/cgmembers/rcredits/forms/cgpaysso.inc
+++ b/cgmembers/rcredits/forms/cgpaysso.inc
@@ -59,11 +59,18 @@ function cgpaySso() {
 
   // Promote this request to the target user. _drupal_session_write() at
   // shutdown reads $user->uid and writes that into the new sessions row, keyed
-  // by session_id(). A non-empty $_SESSION marks the session as "changed" so
-  // the write actually fires (otherwise short-circuits as anonymous-no-data).
+  // by session_id().
   global $user;
   $user = (object) ['uid' => $uid];
-  $_SESSION['cgpay_sso_login'] = REQUEST_TIME;
+
+  // Populate the session vars cgmembers bootstrap reads on the FOLLOWING request
+  // (when the browser arrives at the PHP site with our cookie). r\setAcct() with
+  // no args reads w\svar('myid') / w\svar('agentId') — which are stored as
+  // serialized values under the SVAR_HEADER ('rcredits_') prefix in $_SESSION
+  // (see rweb-subs.inc:svar). Without these, $mya is NULL and r\access() fails
+  // every permission check, so /history etc. redirect to the signin page.
+  $_SESSION[SVAR_HEADER . 'myid'] = serialize($uid);
+  $_SESSION[SVAR_HEADER . 'agentId'] = serialize($uid);
 
   // session_id() now holds the cookie value the browser will send back to demo
   // to authenticate as this user. Drupal writes it to both sid and ssid on

--- a/cgmembers/rcredits/forms/cgpaysso.inc
+++ b/cgmembers/rcredits/forms/cgpaysso.inc
@@ -1,0 +1,83 @@
+<?php
+namespace CG\Web;
+use CG as r;
+use CG\Db as db;
+
+/**
+ * @file
+ * Cross-app SSO endpoint for the SvelteKit cgpay POC.
+ *
+ * The cgpay POC (https://cgpay-poc.commongood.earth) verifies a user's password
+ * against `users.pass` and now also needs to sign that user in on the PHP side,
+ * so menu links from the dashboard can land on the existing member site without
+ * a second login. The flow:
+ *
+ *   1. Browser → POST /api/login on cgpay POC
+ *   2. cgpay POC verifies password (existing)
+ *   3. cgpay POC calls POST /cgpay-sso on this server (server-to-server)
+ *      with X-CG-Internal-Token: <shared secret> and JSON body {"uid": <int>}
+ *   4. This endpoint:
+ *        - verifies the shared secret
+ *        - creates a fresh row in `sessions` for that uid
+ *        - returns the cookie name + sid/ssid for the cgpay POC to forward
+ *   5. cgpay POC responds to the browser with Set-Cookie for that session,
+ *      scoped to Domain=.commongood.earth so the cookie reaches the PHP site
+ *
+ * Shared secret lives in config.json under key `cgpaySsoSecret`. It is rejected
+ * unless both ends present a non-empty matching value.
+ *
+ * This endpoint is NOT called from the browser — only from the cgpay server.
+ * No CORS headers, no session/login UI.
+ */
+function cgpaySso() {
+  if (nni($_SERVER, 'REQUEST_METHOD') !== 'POST') return exitJust(X_SYNTAX);
+
+  // Shared-secret auth. Refuse if config is missing — fail closed, not open.
+  $expected = config('cgpaySsoSecret');
+  $provided = nni($_SERVER, 'HTTP_X_CG_INTERNAL_TOKEN');
+  if (empty($expected) || empty($provided) || !hash_equals($expected, $provided)) {
+    return exitJust(X_UNAUTH);
+  }
+
+  // Parse JSON body
+  $raw = file_get_contents('php://input');
+  $body = json_decode($raw, TRUE);
+  $uid = isset($body['uid']) ? (int) $body['uid'] : 0;
+  if (!$uid) return exitJust(X_SYNTAX);
+
+  // Verify the target account exists and is allowed to use the system
+  $a = r\acct($uid);
+  if (!$a) return exitJust(X_NOTFOUND);
+  if (!$a->ok) return exitJust(X_FORBIDDEN);
+
+  // Fresh session IDs — distinct from the (ephemeral) session of THIS request.
+  $sid = drupal_random_key();
+  $ssid = drupal_random_key();
+
+  // Direct INSERT — the codebase's db\insert() helper expects an 'id' primary-key
+  // column that this table doesn't have (sessions uses sid/ssid as the keys).
+  $row = [
+    'uid' => $uid,
+    'acct' => $uid,              // viewing own account
+    'sid' => $sid,
+    'ssid' => $ssid,
+    'hostname' => ip_address(),
+    'timestamp' => REQUEST_TIME,
+    'cache' => 0,
+    'session' => '',             // Drupal hydrates on the user's next request
+  ];
+  db\q('INSERT INTO sessions SET uid=:uid, acct=:acct, sid=:sid, ssid=:ssid, hostname=:hostname, timestamp=:timestamp, cache=:cache, session=:session', $row);
+
+  // Menu categories for this user. Permission rules live in PHP (cg-menu.inc);
+  // here we just expose top-level categories the cgpay dashboard renders as links.
+  $menu = ['Dashboard', 'History', 'Community', 'Settings'];
+  if ($a->co) $menu[] = 'Company';
+  if ($a->can(B_ADMIN)) $menu[] = 'Admin';
+
+  return exitJson([
+    'cookieName' => session_name(),
+    'sid'        => $sid,
+    'ssid'       => $ssid,
+    'menu'       => $menu,
+  ], X_OK);
+}

--- a/cgmembers/rcredits/forms/cgpaysso.inc
+++ b/cgmembers/rcredits/forms/cgpaysso.inc
@@ -51,15 +51,23 @@ function cgpaySso() {
   if (!$a) return exitJust(X_NOTFOUND);
   if (!$a->ok) return exitJust(X_FORBIDDEN);
 
-  // Promote this request to the target user. setAcct() is what the regular
-  // signin form runs after a verified password (see forms/signin.inc). It
-  // updates the global $user, populates $_SESSION, and lets Drupal's
-  // _drupal_session_write() persist a real session row at end of request.
-  r\setAcct($uid, []);
+  // The SSO request itself came in without a session cookie, so Drupal never
+  // called session_start() at boot — meaning _drupal_session_write() won't fire
+  // automatically at shutdown. Start the session machinery now so the shutdown
+  // handler is wired up.
+  if (!drupal_session_started()) drupal_session_start();
 
-  // session_id() now holds the value Drupal will write to sessions.ssid (and
-  // sessions.sid, since the site is HTTPS-only). That's what the browser will
-  // send back to the PHP host as the SSESS cookie.
+  // Promote this request to the target user. _drupal_session_write() at
+  // shutdown reads $user->uid and writes that into the new sessions row, keyed
+  // by session_id(). A non-empty $_SESSION marks the session as "changed" so
+  // the write actually fires (otherwise short-circuits as anonymous-no-data).
+  global $user;
+  $user = (object) ['uid' => $uid];
+  $_SESSION['cgpay_sso_login'] = REQUEST_TIME;
+
+  // session_id() now holds the cookie value the browser will send back to demo
+  // to authenticate as this user. Drupal writes it to both sid and ssid on
+  // HTTPS-only sites.
   $cookieVal = session_id();
 
   // Menu categories for this user. Permission rules live in PHP (cg-menu.inc);

--- a/cgmembers/rcredits/forms/cgpaysso.inc
+++ b/cgmembers/rcredits/forms/cgpaysso.inc
@@ -23,8 +23,9 @@ use CG\Db as db;
  *   5. cgpay POC responds to the browser with Set-Cookie for that session,
  *      scoped to Domain=.commongood.earth so the cookie reaches the PHP site
  *
- * Shared secret lives in config.json under key `cgpaySsoSecret`. It is rejected
- * unless both ends present a non-empty matching value.
+ * Shared secret lives in config.json under key `cgpaySsoSecret` and is exposed at
+ * boot time as the CGPAY_SSO_SECRET constant (see defs.inc). It is rejected unless
+ * both ends present a non-empty matching value.
  *
  * This endpoint is NOT called from the browser — only from the cgpay server.
  * No CORS headers, no session/login UI.
@@ -33,7 +34,7 @@ function cgpaySso() {
   if (nni($_SERVER, 'REQUEST_METHOD') !== 'POST') return exitJust(X_SYNTAX);
 
   // Shared-secret auth. Refuse if config is missing — fail closed, not open.
-  $expected = config('cgpaySsoSecret');
+  $expected = CGPAY_SSO_SECRET;
   $provided = nni($_SERVER, 'HTTP_X_CG_INTERNAL_TOKEN');
   if (empty($expected) || empty($provided) || !hash_equals($expected, $provided)) {
     return exitJust(X_UNAUTH);


### PR DESCRIPTION
## Summary

The SvelteKit member dashboard POC at https://cgpay-poc.commongood.earth. Verifies passwords against `users.pass` (Drupal phpass), shows a real-data dashboard (balance, recent transactions, pending under each Pay/Receive/Transfer action), and hands off the verified login to the PHP cgmembers site so menu links land users signed in.


## What's in this PR

- `POST /api/login` - Drupal phpass verification, JWT, rate-limited, timing-constant; now also calls the PHP `/cgpay-sso` endpoint and forwards the resulting session + device cookies to the browser
- `GET /api/me/info` - balance + pending invoices (tx_requests) + recent completed txs (txs) + pending bank transfers (txs2) for the dashboard
- Dashboard at `/` - real-data layout, Pay/Receive/Transfer actions with clickable Pending counts, recent activity, footer, nav menu sourced from `/api/login`
- Login page at `/login` - minimal form, real Common Good logo
- Brand component using the real Common Good logo (no more "G")
- Preview routes at `/preview/*` - UI-only design previews (no auth, no real data) used for stakeholder reviews

## Required env

DB_HOST / DB_PORT / DB_USER / DB_PASSWORD / DB_NAME (cgmembers schema)
JWT_SECRET, PHP_SSO_URL, PHP_SSO_SECRET, PHP_COOKIE_DOMAIN, PUBLIC_PHP_BASE_URL

## Companion PR

cgmembers-frame [#35](https://github.com/common-good/cgmembers-frame/pull/35) - adds the PHP /cgpay-sso endpoint this app calls.