### PR TITLE
feat(dashboard): redirect /dashboard to cgpay-poc (William punch list #7)

### DIFF
--- a/cgmembers/rcredits/defs.inc
+++ b/cgmembers/rcredits/defs.inc
@@ -70,6 +70,7 @@ define('STRIPE_SECRET', config('stripeSecret'));
 define('QBO_CREDS', config('qboCreds'));
 define('CLICKUP_CREDS', config('clickupCreds'));
 define('CGPAY_SSO_SECRET', config('cgpaySsoSecret', '')); // shared secret for the SvelteKit cgpay POC /cgpay-sso handoff; empty disables the endpoint
+define('CGPAY_URL', config('cgpayUrl', '')); // SvelteKit POC dashboard URL — if set, /dashboard redirects there so the new dashboard becomes the canonical landing place
 
 $configRay = (array) config('db'); // now look at just the database config array
 foreach (explode(' ', 'name driver host port user pass salt word encryption') as $k) ${"db_$k"} = config($k);

--- a/cgmembers/rcredits/forms/dashboard.inc
+++ b/cgmembers/rcredits/forms/dashboard.inc
@@ -19,7 +19,11 @@ function formDashboard($form, &$sta, $args = '') {
   extract(just('stay', $args, NULL));
 
   if ($mya->admSeeAccts and !$mya->proSe and !$stay) return go('/sadmin/summary'); // admins get way more info
-  
+
+  // Members land on the new SvelteKit POC dashboard when configured (see CGPAY_URL).
+  // /dashboard?stay=1 keeps the user on this PHP dashboard for fallback / debug.
+  if (CGPAY_URL and !$stay) return go(CGPAY_URL);
+
   $special = $endorse = $continue = NULL;
   
   if ($mya->ok and !$mya->co) {


### PR DESCRIPTION
## Summary

when a signed-in member visits `/dashboard` (whether via direct URL or by clicking "Dashboard" in the PHP nav), redirect them to the new SvelteKit dashboard at `cgpay-poc.commongood.earth` instead of rendering the legacy PHP dashboard.

The redirect is config-gated via a new `CGPAY_URL` constant. If empty (e.g. on environments where the SvelteKit POC isn't deployed), the old PHP dashboard renders as before - no behaviour change.

## What's in this PR

| File | Change |
|---|---|
| `cgmembers/rcredits/defs.inc` | Adds `CGPAY_URL` boot-time constant from `config('cgpayUrl', '')` |
| `cgmembers/rcredits/forms/dashboard.inc` | Adds redirect at top of `formDashboard`: if `CGPAY_URL` is set and `?stay=1` isn't passed, `go(CGPAY_URL)` |

## Behaviour

- Signed-in member visits `/dashboard` → 302 → `https://cgpay-poc.commongood.earth/`
- `/dashboard?stay=1` -> renders the legacy PHP dashboard (admin / debug fallback)
- Admin with `admSeeAccts` (existing behaviour) still goes to `/sadmin/summary` first; the cgpay-poc redirect only fires after that branch
- Unsigned visitor -> existing access check sends to `/signin?then=...` first (no change)

## Required config

Add to `shared/config/config.json` on environments where the SvelteKit POC exists:

```json
"cgpayUrl": "https://cgpay-poc.commongood.earth/"
```

Already added on demo as part of testing this PR.

## Tested live

Deployed via Capistrano to demo (release `20260630183802`), menu cache rebuilt, smoke-tested end-to-end:

1. Sign in on cgpay-poc as `abeone`
2. Click History (lands on `demo.commongood.earth/history` signed in)
3. Navigate to `demo.commongood.earth/dashboard` -> redirects to `cgpay-poc.commongood.earth/` ✓

## Companion PR

cgpay `feat/dashboard-punch-list-quick-wins`