### PR TITLE
feat(login): /cgpay-lookup identifier resolution

### DIFF
--- a/cgmembers/rcredits/cg-menu.inc
+++ b/cgmembers/rcredits/cg-menu.inc
@@ -248,6 +248,7 @@ function menu($submenu = '') {
     'ajax' => ['call', 'AJAX', '1', ANY, 'ajax'], // called from our JS scripts
     'api' => ['call', 'API', '1', ANY, 'api'],
     'cgpay-sso' => ['call', 'CGPay SSO', '', ANY, 'cgpaySso'], // server-to-server: SvelteKit cgpay POC handing off a verified login to PHP
+    'cgpay-lookup' => ['call', 'CGPay Lookup', '', ANY, 'cgpayLookup'], // server-to-server: SvelteKit cgpay POC identifier (qid/name/email/phone) -> uid resolution
     'cc' => ['call', 'Credit Card Donation', 'Pay 1', ANY],
     'donate-fbo' => ['call', t('Donate'), 'Pay 1', ANY], // deprecated (use donate instead), but still used by Kibilio as of 11/22/2021
   );

--- a/cgmembers/rcredits/forms/cgpaylookup.inc
+++ b/cgmembers/rcredits/forms/cgpaylookup.inc
@@ -1,0 +1,58 @@
+<?php
+namespace CG\Web;
+use CG as r;
+use CG\Db as db;
+use CG\Util as u;
+
+/**
+ * @file
+ * Identifier-lookup endpoint for the SvelteKit cgpay POC.
+ *
+ * The POC's login form lets the user type any of: account code (QID or short),
+ * username, full name (handled via shortName), email, or phone number. PHP owns
+ * the matching logic — r\loginString() already handles QID/short/email/name
+ * (including the encrypted-email path), and this endpoint extends it with phone.
+ *
+ * Flow:
+ *   POC POST /cgpay-lookup with X-CG-Internal-Token: <shared secret>
+ *     body: {"identifier": "<whatever the user typed>"}
+ *   This endpoint returns:
+ *     200 {"uid": <int>}  on match
+ *     401  on bad/missing shared secret
+ *     400  on missing identifier
+ *     404  on no match
+ *
+ * The POC then SELECTs `users.pass` by uid and verifies the password itself.
+ *
+ * Shared secret is the same one used by /cgpay-sso (CGPAY_SSO_SECRET, see
+ * defs.inc). One secret for both endpoints — no point splitting it.
+ */
+function cgpayLookup() {
+  if (nni($_SERVER, 'REQUEST_METHOD') !== 'POST') return exitJust(X_SYNTAX);
+
+  $expected = CGPAY_SSO_SECRET;
+  $provided = nni($_SERVER, 'HTTP_X_CG_INTERNAL_TOKEN');
+  if (empty($expected) || empty($provided) || !hash_equals($expected, $provided)) {
+    return exitJust(X_UNAUTH);
+  }
+
+  $body = json_decode(file_get_contents('php://input'), TRUE);
+  $identifier = isset($body['identifier']) ? trim((string) $body['identifier']) : '';
+  if ($identifier === '') return exitJust(X_SYNTAX);
+
+  // r\loginString covers: account code (QID + short code), email, and the
+  // username/short-name match — including the encrypted-email path.
+  $uid = r\loginString($identifier);
+
+  // Fallback: phone number. cgmembers' api.inc has phone matching but it's
+  // currently gated off (`FALSE and …`). We enable it here when r\loginString
+  // returns nothing AND the input looks phone-shaped.
+  if (!$uid && preg_match('/^[\+\(\)\.\- 0-9]{7,}$/', $identifier)) {
+    $phone = u\cry('P', u\fmtPhone($identifier, '+n'));
+    $uid = db\get('uid', 'users', 'phone=:phone ORDER BY :IS_CO', compact('phone'));
+  }
+
+  if (!$uid) return exitJust(X_NOTFOUND);
+
+  return exitJson(['uid' => (int) $uid], X_OK);
+}


### PR DESCRIPTION
## Summary

the SvelteKit cgpay POC login form now accepts an **account code (QID or short code), full name, username, email, or phone number**. cgmembers already had this matching logic (`r\loginString` covers everything but phone; api.inc has phone but with `FALSE and` gating it off). This PR exposes it as a server-to-server endpoint so the POC doesn't reimplement the crypto or QID translation.

## What's in this PR

| File | Change |
|---|---|
| `cgmembers/rcredits/forms/cgpaylookup.inc` | New endpoint - shared-secret auth, wraps `r\loginString`, adds phone-number fallback |
| `cgmembers/rcredits/cg-menu.inc` | Registers the `cgpay-lookup` route |

## How it works

POC POSTs `{"identifier": "<what the user typed>"}` with `X-CG-Internal-Token: <shared secret>`. Handler:

1. Verifies shared secret (`CGPAY_SSO_SECRET` - same one as `/cgpay-sso`, no point splitting)
2. Runs `r\loginString($identifier)` - covers QID, short account code, email (encrypted), and username/short-name
3. **Fallback**: if no match and the input looks phone-shaped (`/^[\+\(\)\.\- 0-9]{7,}$/`), tries `db\get('uid', 'users', 'phone=:phone ...', u\cry('P', u\fmtPhone($id, '+n')))`
4. Returns `{"uid": <int>}` on match, 404 on no match, 401 on bad secret, 400 on missing identifier

## Companion PR

cgpay `feat/multi-format-signin` - SvelteKit `/api/login` calls this endpoint and renames the form field from "Username" to "Account ID".
