### PR TITLE
Fix/cgbutton acct inactive

### DIFF
--- a/cgmembers/rcredits/cg.inc
+++ b/cgmembers/rcredits/cg.inc
@@ -1296,7 +1296,7 @@ function txPermErr($a1, $a2, $taking = TRUE, $neg = FALSE) {
   if (!$a1->ok) return be\txRet(FALSE, t('Requesting account is inactive.'));
   
   $confirmed = ($a1->co ? ($a1->agentA->confirmed or $a1->helperA->confirmed) : $a1->confirmed);
-  if (!$confirmed and !$a1->isCanonic and !$a2->isCanonic and $a1->id != CGID and !in($a2->id, BUCKET_UIDS)) { // actor is not confirmed (but newbs can transact with bank and CG)
+  if (!$confirmed and !$a1->isCanonic and !$a2->isCanonic and $a1->id != CGID and !in($a2->id, BUCKET_UIDS)) { // actor is not confirmed (but noobs can transact with bank and CG)
     if ($a1->helper != $a2->id) { // unless doing business with who invited you
       if (!$a1->hasId or $a1->risk('ssnOff')) {
         $atHome = in(r\serverUid(), [$a1->community, $a2->community]) ? ($a1->community == $a2->community) : (substr($a1->zip, 0, 3) == substr($a2->zip, 0, 3) or u\earthDistance($a1->latitude, $a1->longitude, $a2->latitude, $a2->longitude) < 20);

--- a/cgmembers/rcredits/classes/acct.class
+++ b/cgmembers/rcredits/classes/acct.class
@@ -228,7 +228,7 @@ class Acct {
       case 'slave': return ($jid = $a->jid and $jid < $a->id); // slave in a joint account
       case 'jA': return $a->jid ? r\acct($a->jid) : NULL;
       case 'masterA': return $a->slave ? $a->jA : $a;
-      case 'helperA': return $a->helper ? r\acct($a->helper) : '';
+      case 'helperA': return r\acct($a->helper ?: UID_SUPER);
       case 'usa': return ($a->country == US_COUNTRY_ID);
       case 'card': return ($a->ok and $a->stepsDone('card'));
       case 'vote': return ($a->ok and $a->stepsDone('vote'));

--- a/cgmembers/rcredits/defs.inc
+++ b/cgmembers/rcredits/defs.inc
@@ -427,6 +427,8 @@ const HAS_XFEE = "data LIKE '%s:4:\"xfee\";%'"; // sql to recognize a transactio
 const R_DEPOSIT_RETURN_FEE = 20; // what we charge members for a second bounced transfer
 define('FS_NOTE', t('fiscal sponsorship fee')); // standard message for this in tx_timed / aux transactions
 const FS_FEE_SPREAD = 3; // how many points between starting and end fiscal sponsorship fee percentages
+const FSCATMAP = 'fsFeeCat:FS-FEE, fsInCat:D-FBO, stepupCat:D-STEPUP, fsStepupCat:D-FBO-STEPUP, fsOutCat1:FIRST-FS-EXPENSE, fsOutCat9:LAST-FS-EXPENSE, fsToPerson:GRANT-PERSON, fsToOrg:GRANT-ORG';
+
 const TRIALCO_AMT_LIMIT = 1000; // maximum payments received by a trial (dependent company) account
 //const TRIALCO_DAY_LIMIT = 14; // maximum number of days for a trial company
 const CREDIT_WITH_SSN = 200; // amount of initial creditline when SSN is verified

--- a/cgmembers/rcredits/forms/pay.inc
+++ b/cgmembers/rcredits/forms/pay.inc
@@ -20,6 +20,7 @@ function formPay($form, &$sta, $args = NULL) {
 
   if ($code = nni($args, 'code')) { // customer clicked a coded button
     if (!$ray = getCGPayArgs($args, $mya) or !$coA = nni($ray, 'coA')) return; // error message already shown
+    if (!$coA->ok) return softErr('inactive');
     extract(just($codeFlds, $ray, NULL));
   } else { // vanilla CG donation page
     foreach (ray($codeFlds) as $k) $$k = NULL;

--- a/cgmembers/rcredits/forms/pay.inc
+++ b/cgmembers/rcredits/forms/pay.inc
@@ -20,7 +20,6 @@ function formPay($form, &$sta, $args = NULL) {
 
   if ($code = nni($args, 'code')) { // customer clicked a coded button
     if (!$ray = getCGPayArgs($args, $mya) or !$coA = nni($ray, 'coA')) return; // error message already shown
-    if (!$coA->ok) return softErr('inactive');
     extract(just($codeFlds, $ray, NULL));
   } else { // vanilla CG donation page
     foreach (ray($codeFlds) as $k) $$k = NULL;
@@ -311,6 +310,7 @@ function getCGPayArgs($args, $mya) {
 
   if ($expires and $expires < now()) return softErr(tr('button expired'));
   if (!$account or !$coA = r\acct($account)) return exitErr(t('That account does not exist.'));
+  if (!$coA->ok) return softErr('inactive');
   $coId = $coA->id;
   if ($mya and $mya->id == $coId) return softErr(t('Making a payment to yourself is not permitted.'));
   if (isset($s_amount) and $err = u\badAmount($s_amount, '>0')) return exitErr(t('Parameter "amount" (suggested amount): %err', compact('err')));

--- a/cgmembers/rcredits/forms/tx.inc
+++ b/cgmembers/rcredits/forms/tx.inc
@@ -13,7 +13,7 @@ use CG\Db as db;
 function formTx($form, &$sta, $type, $args = '') {
   extract(just('who amount goods purpose', $args, ''));
   global $mya;
-
+  
   $fbo = $mya->sponsored;
   $hasCats = r\hasCats($mya->uid) ?: 0;
 
@@ -73,7 +73,9 @@ function formTx($form, &$sta, $type, $args = '') {
   
   $admin = $mya->admNonmemberTx;
   list ($byDft, $byCheck) = [B_ACH, B_CHECK];
-  jsx('tx', compact(ray('field question selfErr payDesc chargeDesc fbo admin hasCats byDft byCheck')));
+  $porch = basename($_SERVER['REQUEST_URI']); // pay or charge (or dashboard, but that's going away soon)
+
+  jsx('tx', compact(ray('porch field question selfErr payDesc chargeDesc fbo admin hasCats byDft byCheck')));
   
   $paying = hidFld($pay);
   $hasCats = hidFld($hasCats);

--- a/cgmembers/rcredits/js/scraps.js
+++ b/cgmembers/rcredits/js/scraps.js
@@ -304,8 +304,9 @@ function doit(what, vs) {
     var pay;
     var purpose = $('#edit-purpose');
     var cat = $('#edit-cat');
-    $('.btn-pay, .btn-charge').click(function () {
-      pay = has($(this).attr('class'), 'btn-pay');
+
+    var porch = function () {
+      pay = vs['porch'] == 'dashboard' ? has($(this).attr('class'), 'btn-pay') : (vs['porch'] == 'pay');
       var desc = vs[pay ? 'payDesc' : 'chargeDesc'];
       $('#dashboard').hide();
       $('.w-pay').toggle(pay);
@@ -329,7 +330,10 @@ function doit(what, vs) {
       vs['restrict'] = pay ? ':IS_OK' : '';
       suggestWhoScrap();
       mem0Click(true);
-    });
+    };
+    
+    if (vs['porch'] == 'dashboard') $('.btn-pay, .btn-charge').click(porch); else porch();
+    
     if (vs['hasCats'] == 1) $('#edit-who').change(function () {
       var otherId = $('.whoId', $(this).parents('form:first'));
       if (purpose.val() == '' || cat.val() == '') post('suggestTxDesc', {

--- a/cgmembers/rcredits/rweb/features/ccpay.feature
+++ b/cgmembers/rcredits/rweb/features/ccpay.feature
@@ -21,6 +21,16 @@ Setup:
   | .ZZB |       0 |
   | .ZZC |       0 |
 
+Scenario: A non-member clicks a link to donate to a closed account
+  Given button code "buttonCode" for:
+  | account | secret | for    |*
+  | .ZZC    | Cc3    | donate |
+  And members have:
+  | uid  | flags               |*
+  | .ZZC | member,co,confirmed |
+  When member "?" visits "pay/code=%buttonCode"
+  Then we say "error": "inactive"
+  
 Scenario: A non-member clicks a link to donate to a ccOk organization by Stripe
   Given button code "buttonCode" for:
   | account | secret | for    |*

--- a/cgmembers/rcredits/rweb/features/cgpay.feature
+++ b/cgmembers/rcredits/rweb/features/cgpay.feature
@@ -31,7 +31,17 @@ Scenario: A member clicks an expired pay button
   | .ZZC    | Cc3    | food | 23.50  | %now-1d |
   When member "?" visits page "pay/code=%buttonCode"
   Then we say "error": "button expired"
-
+  
+Scenario: A member clicks a pay button for a closed account
+  Given button code "buttonCode" for:
+  | account | secret | item | amount | expires |*
+  | .ZZC    | Cc3    | food | 23.50  |         |
+  And members have:
+  | uid  | flags               |*
+  | .ZZC | member,co,confirmed |
+  When member "?" visits page "pay/code=%buttonCode"
+  Then we say "error": "inactive"
+  
 Scenario: A member submits a pay button payment with account ID
   Given button code "buttonCode" for:
   | account | secret | item | amount |*

--- a/cgmembers/rcredits/rweb/queries.inc
+++ b/cgmembers/rcredits/rweb/queries.inc
@@ -15,7 +15,6 @@ use CG\Util as u;
  */
 
 global $mya;
-const FSCATMAP = 'fsFeeCat:FS-FEE, fsInCat:D-FBO, stepupCat:D-STEPUP, fsStepupCat:D-FBO-STEPUP, fsOutCat1:FIRST-FS-EXPENSE, fsOutCat9:LAST-FS-EXPENSE, fsToPerson:GRANT-PERSON, fsToOrg:GRANT-ORG';
 
 $bizQ = 'SELECT uid as payee, goods, SUM(IF(amount>0,amount,0)) AS sales, SUM(IF(amount<0,amount,0)) AS payments, COUNT(*) AS cnt FROM tx_entries JOIN tx_hdrs USING (xid) WHERE goods=:FOR_GOODS AND created BETWEEN';
 $gifts = r\annualAmt();

--- a/cgmembers/rcredits/rweb/rweb.steps
+++ b/cgmembers/rcredits/rweb/rweb.steps
@@ -405,7 +405,9 @@ function weSayWithSubs($type, $index, $subs) {return t\weSayWithSubs($type, $ind
  *
  * in: TEST bank AMemberMovesTooLittleToTheBank
  *     TEST bank AMemberTriesToGoBelowTheirMinimum
+ *     TEST ccpay ANonmemberClicksALinkToDonateToAClosedAccount
  *     TEST cgpay AMemberClicksAnExpiredPayButton
+ *     TEST cgpay AMemberClicksAPayButtonForAClosedAccount
  *     TEST company AMemberUpdatesCompanyInfo
  *     TEST connect AnActiveMemberConnectsABankAccountWithABadRoutingNumber
  *     TEST contact AMemberUpdatesContactInfo
@@ -879,6 +881,7 @@ function balances($list) {return t\balances($list);}
  *     MAKE bank AMemberRequestsMoreThanTheTotalTheBankAllowsInOneDay
  *     MAKE cgpay AMemberClicksAPayButton
  *     MAKE cgpay AMemberClicksAnExpiredPayButton
+ *     MAKE cgpay AMemberClicksAPayButtonForAClosedAccount
  *     MAKE cgpay AMemberClicksAPayButtonWithVariableAmount
  *     MAKE cgpay AMemberClicksAButtonToBuyStoreCredit
  *     MAKE cgpay AMemberClicksAButtonToBuyStoreCreditForADifferentAmount
@@ -1238,10 +1241,12 @@ function statisticsGetSet($time) {
  * in: MAKE backing AMemberDecreasesBackingAmount
  *     MAKE bank ASlaveMemberRequestsATransfer
  *     MAKE boxes AMemberTransactsAndBoxIdGetsRecorded
+ *     MAKE ccpay ANonmemberClicksALinkToDonateToAClosedAccount
  *     MAKE ccpay ANonmemberClicksALinkToDonateToAnUnauthorizedOrganization
  *     MAKE ccpay ANonmemberConfirmsADonationToASponsoredOrganizationByCreditCard
  *     MAKE ccpay ANonmemberConfirmsAPaymentToACcOkOrganizationByCreditCard
  *     MAKE ccpay AMemberDonatesToACcOkOrganization
+ *     MAKE cgpay AMemberClicksAPayButtonForAClosedAccount
  *     MAKE cgpay AMemberRedeemsStoreCreditOverspendingAZeroBalance
  *     MAKE coupons AMemberCompanyCreatesAGiftCoupon
  *     BOTH coupons AMemberRedeemsAGiftCoupon
@@ -2444,7 +2449,8 @@ function memberAjaxWith($id, $op, $ray) {
 /**
  * member (ARG) visits (ARG)
  *
- * in: MAKE ccpay ANonmemberClicksALinkToDonateToACcOkOrganizationByStripe
+ * in: MAKE ccpay ANonmemberClicksALinkToDonateToAClosedAccount
+ *     MAKE ccpay ANonmemberClicksALinkToDonateToACcOkOrganizationByStripe
  *     MAKE ccpay ANonmemberClicksALinkToDonateToAnUnauthorizedOrganization
  *     MAKE ccpay ANonmemberClicksALinkToPayACcOkOrganizationByStripe
  *     MAKE fbo ANonmemberDonatesToASponsoredMemberByCheck
@@ -2622,12 +2628,14 @@ function weShowPDFWith($list) {return t\pdfHas($list);}
  * button code (ARG) for: (ARG)
  *
  * in: MAKE accredit AMemberTriesToBuyCreditWithCredit
+ *     MAKE ccpay ANonmemberClicksALinkToDonateToAClosedAccount
  *     MAKE ccpay ANonmemberClicksALinkToDonateToACcOkOrganizationByStripe
  *     MAKE ccpay ANonmemberClicksALinkToDonateToAnUnauthorizedOrganization
  *     MAKE ccpay ANonmemberClicksALinkToPayACcOkOrganizationByStripe
  *     MAKE ccpay AMemberDonatesToACcOkOrganization
  *     MAKE cgpay AMemberClicksAPayButton
  *     MAKE cgpay AMemberClicksAnExpiredPayButton
+ *     MAKE cgpay AMemberClicksAPayButtonForAClosedAccount
  *     MAKE cgpay AMemberSubmitsAPayButtonPaymentWithAccountID
  *     MAKE cgpay AMemberClicksAPayButtonWithVariableAmount
  *     MAKE cgpay AMemberSubmitsAPayButtonPaymentWithAccountIDAndChosenAmount


### PR DESCRIPTION
A company's CGPay buttons continue to allow customers or donors to transfer money to the company's account after the account is closed/inactive. Not good. This branch fixes it and tests the fix.