### PR TITLE
Fix/cgbutton acct inactive

### DIFF
--- a/cgmembers/includes/errors.inc
+++ b/cgmembers/includes/errors.inc
@@ -19,7 +19,7 @@ include_once R_ROOT . '/cg-util.inc';
  * @ingroup logging_severity_levels
  */
 function drupal_error_levels() {
-  return [
+  $levels = [
     E_ERROR => ['Error', WATCHDOG_ERROR],
     E_WARNING => ['Warning', WATCHDOG_WARNING],
     E_PARSE => ['Parse error', WATCHDOG_ERROR],
@@ -33,9 +33,10 @@ function drupal_error_levels() {
     E_USER_NOTICE => ['User notice', WATCHDOG_NOTICE],
     E_DEPRECATED => ['Deprecated function', WATCHDOG_DEPRECATED],
     E_USER_DEPRECATED => ['User deprecated function', WATCHDOG_USER_DEPRECATED],
-    E_STRICT => ['Strict warning', WATCHDOG_DEBUG],
     E_RECOVERABLE_ERROR => ['Recoverable fatal error', WATCHDOG_ERROR],
   ];
+  if (defined('E_STRICT')) $levels[E_STRICT] = ['Strict warning', WATCHDOG_DEBUG]; // E_STRICT removed in PHP 8.4
+  return $levels;
 }
 
 /**
@@ -63,6 +64,7 @@ function handleError($level, $msg, $file, $line, $trace = NULL) {
     foreach ($ignore as $k) if (strpos($msg, $k) !== FALSE) return; // work around flaws in fopen and file_get_contents
   }
   if ($severity == WATCHDOG_DEBUG) return;
+  if ($severity == WATCHDOG_DEPRECATED or $severity == WATCHDOG_USER_DEPRECATED) return; // PHP 8.4+ deprecations should not crash the bootstrap
 ///  debug($context); echo pr($context); // handy when debugging
 
   $nasty = ($severity < WATCHDOG_WARNING);

--- a/cgmembers/rcredits/boot.inc
+++ b/cgmembers/rcredits/boot.inc
@@ -5,8 +5,10 @@
  * Also used by /do.php, for no-sign-in database changes
  */
 
+error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED); // suppress PHP 8.4+ deprecations until codebase migrates off PDO::MYSQL_ATTR_* and implicit nullable params
+
 strip($_POST); strip($_GET); // No HTML input EVER (unless encoded in a way we expect)
- 
+
 global $base_url, $base_path, $base_root;
 global $databases, $drupal_hash_salt;
 global $cookie_domain, $is_https, $base_secure_url, $base_insecure_url;
@@ -36,10 +38,10 @@ ini_set('session.use_trans_sid', '0');
 ini_set('session.cache_limiter', ''); // Don't send HTTP headers using PHP's session handler.
 ini_set('session.cookie_httponly', '1'); // Use httponly session cookies.
 
-ini_set('error_reporting', E_ALL);
+ini_set('error_reporting', E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED); // mirror the early error_reporting() call
 ini_set('max_execution_time', isDEV ? 0 : (4 * 60)); // don't ever timeout processing when developing
-ini_set('session.gc_probability', 1); // garbage collection this fraction of the time on startup (numerator)
-ini_set('session.gc_divisor', 0); // (denominator) - disable random garbage collection (do it in cron instead)
+ini_set('session.gc_probability', 0); // disable random garbage collection (do it in cron instead) - PHP 8 disallows gc_divisor=0
+ini_set('session.gc_divisor', 100);
 define('SESSION_LIFE', (nni($_COOKIE, 'pw2') or nni($_POST, 'pw2')) ? (12 * HOUR_SECS) : (24 * MIN_SECS)); // standard 24 mins (more for admin)
 //define('SESSION_LIFE', (nni($_COOKIE, 'pw2') or nni($_POST, 'pw2')) ? (5) : (2 * MIN_SECS)); // for testing
 ini_set('session.gc_maxlifetime', SESSION_LIFE); // session timeout (and garbage collection happens)

--- a/cgmembers/rcredits/cg-backend.inc
+++ b/cgmembers/rcredits/cg-backend.inc
@@ -1179,7 +1179,7 @@ function thanks($xid, $item = NULL, $only = FALSE) {
 //    $note = (!$member and u\starts($notes, fmtDt(now(), 'dmY'))) ? str_replace(': ', '', strstr(strstr($notes, ': ') . "\n", "\n", TRUE)) : '';
     
     $amtDpy = u\fmtAmt($amount) . ($period != PER_1 ? (' ' . r\recurDesc($period, $periods)) : '');
-    $subs0 += ray('date item amount', fmtDt(now()), $item, $amtDpy);
+    $subs0 += ray('date item amount', fmtDt($tx->created), $item, $amtDpy);
 
     $subs = $subs0 + ray('fromName fromPhone fromAddress fromEmail', $fullName, u\fmtPhone($phone), $postalAddr, $email);
     unset($subs['fullName']); // salutation to co name, not payer name

--- a/cgmembers/rcredits/cg-backend.inc
+++ b/cgmembers/rcredits/cg-backend.inc
@@ -1012,9 +1012,9 @@ function sendNotifications($mya, $type, $tx, $shortfall, $doTell = TRUE) {
     $did = ''; // no real-time report from here
     $appMsg = $toMe ? '' : t('drew from');
   } elseif (in($type, 'payment, invoice payment')) {
-    $notices = ['you paid', 'paid you'];
-    $did = t('paid');
-    $appMsg = 'paid';
+    $notices = u\order($positive, 'you paid', 'paid you');
+    $did = $positive ? t('paid') : t('received from');
+    $appMsg = $did;
   } elseif ($type == 'undo') {
     if ($tx->otherA->isBank()) {
       $notices = ['', 'bank tx canceled'];

--- a/cgmembers/rcredits/cg-menu.inc
+++ b/cgmembers/rcredits/cg-menu.inc
@@ -248,6 +248,7 @@ function menu($submenu = '') {
     'ajax' => ['call', 'AJAX', '1', ANY, 'ajax'], // called from our JS scripts
     'api' => ['call', 'API', '1', ANY, 'api'],
     'cgpay-sso' => ['call', 'CGPay SSO', '', ANY, 'cgpaySso'], // server-to-server: SvelteKit cgpay POC handing off a verified login to PHP
+    'cgpay-lookup' => ['call', 'CGPay Lookup', '', ANY, 'cgpayLookup'], // server-to-server: SvelteKit cgpay POC identifier (qid/name/email/phone) -> uid resolution
     'cc' => ['call', 'Credit Card Donation', 'Pay 1', ANY],
     'donate-fbo' => ['call', t('Donate'), 'Pay 1', ANY], // deprecated (use donate instead), but still used by Kibilio as of 11/22/2021
   );

--- a/cgmembers/rcredits/cg-menu.inc
+++ b/cgmembers/rcredits/cg-menu.inc
@@ -249,6 +249,7 @@ function menu($submenu = '') {
     'api' => ['call', 'API', '1', ANY, 'api'],
     'cgpay-sso' => ['call', 'CGPay SSO', '', ANY, 'cgpaySso'], // server-to-server: SvelteKit cgpay POC handing off a verified login to PHP
     'cgpay-lookup' => ['call', 'CGPay Lookup', '', ANY, 'cgpayLookup'], // server-to-server: SvelteKit cgpay POC identifier (qid/name/email/phone) -> uid resolution
+    'cgpay-grants' => ['call', 'CGPay Grants', '', ANY, 'cgpayGrants'], // server-to-server: SvelteKit cgpay POC expected-grant list + create
     'cc' => ['call', 'Credit Card Donation', 'Pay 1', ANY],
     'donate-fbo' => ['call', t('Donate'), 'Pay 1', ANY], // deprecated (use donate instead), but still used by Kibilio as of 11/22/2021
   );

--- a/cgmembers/rcredits/cg-menu.inc
+++ b/cgmembers/rcredits/cg-menu.inc
@@ -247,6 +247,7 @@ function menu($submenu = '') {
     'pos' => ['call', 'POS', '1', ANY, 'pos'], // called from the CGPay app
     'ajax' => ['call', 'AJAX', '1', ANY, 'ajax'], // called from our JS scripts
     'api' => ['call', 'API', '1', ANY, 'api'],
+    'cgpay-sso' => ['call', 'CGPay SSO', '', ANY, 'cgpaySso'], // server-to-server: SvelteKit cgpay POC handing off a verified login to PHP
     'cc' => ['call', 'Credit Card Donation', 'Pay 1', ANY],
     'donate-fbo' => ['call', t('Donate'), 'Pay 1', ANY], // deprecated (use donate instead), but still used by Kibilio as of 11/22/2021
   );

--- a/cgmembers/rcredits/cg-strings.inc
+++ b/cgmembers/rcredits/cg-strings.inc
@@ -460,6 +460,7 @@ EOF
   'email plus' => t('If you want to use the same email address for this account, add a plus sign (+) and an arbitrary tag to the local part, for example "%emailTagged".'), // used in user.module
   'forgot password' => t('If you just forgot the password to the other account, <%a>click here</a> to request a new password.'), // used in user.module
   'bad name' => t('That is not a plausible name.'),
+  'code FLN' => t('There is a problem with your account application. Please contact our support staff at %CGF_PHONE. Tell them code FLN.'),
   'bad phone' => t('That is not a proper phone number.'),
   'not your account' => t('That is not your account ID.'),
   'bad account number' => t('Your bank account number must be 3-17 digits long.'),

--- a/cgmembers/rcredits/cg-strings.inc
+++ b/cgmembers/rcredits/cg-strings.inc
@@ -273,6 +273,7 @@ EOF
   'wire fee' => t('wire transfer fee'),
   'cover cc fee' => t('<span>Check here to cover the transaction processing fee (%CC_PCT% + %CC_PLUS¢).</span>'), // must include <span> (see 'pay' in scraps.js)
   'cover FS fee' => t('<span>Check here to cover the fiscal sponsorship fee (%fee%).</span>'), // must include <span> (see 'pay' in scraps.js)
+  'fs fee adjust' => t('fiscal sponsorship fee adjustment'),
   'sponsee notified' => t('The sponsee has been notified that this grant was received, but needs documentation.'),
   'grantdoc-required' => t('Your %amt grant from %grantorName has been received, but needs documentation before the funds can be released to your account. At your convenience, please email a copy of the grant agreement to %PROJECT at %CGF_EMAIL. Then sign in to your account and on the Company menu choose "Grants Expected" to enter the date you emailed us the agreement.'),
     

--- a/cgmembers/rcredits/cg.inc
+++ b/cgmembers/rcredits/cg.inc
@@ -1296,7 +1296,7 @@ function txPermErr($a1, $a2, $taking = TRUE, $neg = FALSE) {
   if (!$a1->ok) return be\txRet(FALSE, t('Requesting account is inactive.'));
   
   $confirmed = ($a1->co ? ($a1->agentA->confirmed or $a1->helperA->confirmed) : $a1->confirmed);
-  if (!$confirmed and !$a1->isCanonic and !$a2->isCanonic and $a1->id != CGID and !in($a2->id, BUCKET_UIDS)) { // actor is not confirmed (but newbs can transact with bank and CG)
+  if (!$confirmed and !$a1->isCanonic and !$a2->isCanonic and $a1->id != CGID and !in($a2->id, BUCKET_UIDS)) { // actor is not confirmed (but noobs can transact with bank and CG)
     if ($a1->helper != $a2->id) { // unless doing business with who invited you
       if (!$a1->hasId or $a1->risk('ssnOff')) {
         $atHome = in(r\serverUid(), [$a1->community, $a2->community]) ? ($a1->community == $a2->community) : (substr($a1->zip, 0, 3) == substr($a2->zip, 0, 3) or u\earthDistance($a1->latitude, $a1->longitude, $a2->latitude, $a2->longitude) < 20);

--- a/cgmembers/rcredits/classes/acct.class
+++ b/cgmembers/rcredits/classes/acct.class
@@ -228,7 +228,7 @@ class Acct {
       case 'slave': return ($jid = $a->jid and $jid < $a->id); // slave in a joint account
       case 'jA': return $a->jid ? r\acct($a->jid) : NULL;
       case 'masterA': return $a->slave ? $a->jA : $a;
-      case 'helperA': return $a->helper ? r\acct($a->helper) : '';
+      case 'helperA': return r\acct($a->helper ?: UID_SUPER);
       case 'usa': return ($a->country == US_COUNTRY_ID);
       case 'card': return ($a->ok and $a->stepsDone('card'));
       case 'vote': return ($a->ok and $a->stepsDone('vote'));

--- a/cgmembers/rcredits/defs.inc
+++ b/cgmembers/rcredits/defs.inc
@@ -424,6 +424,7 @@ const DUPTX_SECS = 3 * MIN_SECS; // number of minutes before a duplicate transac
 const HAS_XFEE = "data LIKE '%s:4:\"xfee\";%'"; // sql to recognize a transaction that has an exchange fee
 const R_DEPOSIT_RETURN_FEE = 20; // what we charge members for a second bounced transfer
 define('FS_NOTE', t('fiscal sponsorship fee')); // standard message for this in tx_timed / aux transactions
+const FS_FEE_SPREAD = 3; // how many points between starting and end fiscal sponsorship fee percentages
 const TRIALCO_AMT_LIMIT = 1000; // maximum payments received by a trial (dependent company) account
 //const TRIALCO_DAY_LIMIT = 14; // maximum number of days for a trial company
 const CREDIT_WITH_SSN = 200; // amount of initial creditline when SSN is verified

--- a/cgmembers/rcredits/defs.inc
+++ b/cgmembers/rcredits/defs.inc
@@ -69,6 +69,7 @@ define('STRIPE_PUBLIC', config('stripePublic'));
 define('STRIPE_SECRET', config('stripeSecret'));
 define('QBO_CREDS', config('qboCreds'));
 define('CLICKUP_CREDS', config('clickupCreds'));
+define('CGPAY_SSO_SECRET', config('cgpaySsoSecret', '')); // shared secret for the SvelteKit cgpay POC /cgpay-sso handoff; empty disables the endpoint
 
 $configRay = (array) config('db'); // now look at just the database config array
 foreach (explode(' ', 'name driver host port user pass salt word encryption') as $k) ${"db_$k"} = config($k);

--- a/cgmembers/rcredits/defs.inc
+++ b/cgmembers/rcredits/defs.inc
@@ -70,6 +70,7 @@ define('STRIPE_SECRET', config('stripeSecret'));
 define('QBO_CREDS', config('qboCreds'));
 define('CLICKUP_CREDS', config('clickupCreds'));
 define('CGPAY_SSO_SECRET', config('cgpaySsoSecret', '')); // shared secret for the SvelteKit cgpay POC /cgpay-sso handoff; empty disables the endpoint
+define('CGPAY_URL', config('cgpayUrl', '')); // SvelteKit POC dashboard URL — if set, /dashboard redirects there so the new dashboard becomes the canonical landing place
 
 $configRay = (array) config('db'); // now look at just the database config array
 foreach (explode(' ', 'name driver host port user pass salt word encryption') as $k) ${"db_$k"} = config($k);

--- a/cgmembers/rcredits/defs.inc
+++ b/cgmembers/rcredits/defs.inc
@@ -33,10 +33,10 @@ const DEV_VPRIVK_FLNM = R_ROOT . '/misc/devkeys/v.privk'; // location of private
 const DEV_CONFIG_FLNM = R_ROOT . '/misc/config-models/cgAdmin-dev.html'; // location of config file for vKeyPw for testing
 const T_BANK_ACCT = 'USkk21187028112345'; // bank account for tests
 const BANK_TX_LIMITS = '1:30000,7:9999999,52:9999999,365:9999999'; // WAS 1:30000,7:80000,52:160000,365:320000 member limits per day (subject to ACH limits), week, 7-week, year (admin is exempt, so members can request exceptions)
-const BANK_KEYS = 'name routing acctIn acctOut coName coIdPrefix balanced achPrefix sameDay cutoff maxDailyAchIn maxDailyAchOut maxDailyAchTotal';
-const BANK_DATA = [ // our bank's name (<=23chars), routing number, in, out, our company name, company ID prefix, balanced?, prefix ("_" means blank), same-day requests, cutoff time, maximum daily ACH total IN, OUT, TOTAL
+const BANK_KEYS = 'name routing acctIn acctOut coName coNameCR coIdPrefix balanced achPrefix sameDay cutoff maxDailyAchIn maxDailyAchOut maxDailyAchTotal';
+const BANK_DATA = [ // our bank's name (<=23chars), routing number, in, out, our company name, our company name for ACH Credit requests, company ID prefix, balanced?, prefix ("_" means blank), same-day requests, cutoff time, maximum daily ACH total IN, OUT, TOTAL
 //  'BSL' => 'Brattleboro S&L, 211672476, 500718598, 500718598, Common Good, 1, 0, _, 0, 3pm, 9999999, 9999999, 100000',
-  'CFB' => 'Climate First Bank, 063117011, 1079807, 1079807, Common Good MM, 9, 0, _, 1, 5pm, 5000, 30000, 9999999',
+  'CFB' => 'Climate First Bank, 063117011, 1079807, 1079807, Common Good MM, Common Good CR, 9, 0, _, 1, 2pm, 5000, 30000, 9999999',
 ];
 const T_MAX_DAILY_ACH_IN = 1234; // maxDailyAchIn for tests
 const T_MAX_DAILY_ACH_OUT = 9876; // maxDailyAchOut for tests

--- a/cgmembers/rcredits/defs.inc
+++ b/cgmembers/rcredits/defs.inc
@@ -427,6 +427,8 @@ const HAS_XFEE = "data LIKE '%s:4:\"xfee\";%'"; // sql to recognize a transactio
 const R_DEPOSIT_RETURN_FEE = 20; // what we charge members for a second bounced transfer
 define('FS_NOTE', t('fiscal sponsorship fee')); // standard message for this in tx_timed / aux transactions
 const FS_FEE_SPREAD = 3; // how many points between starting and end fiscal sponsorship fee percentages
+const FSCATMAP = 'fsFeeCat:FS-FEE, fsInCat:D-FBO, stepupCat:D-STEPUP, fsStepupCat:D-FBO-STEPUP, fsOutCat1:FIRST-FS-EXPENSE, fsOutCat9:LAST-FS-EXPENSE, fsToPerson:GRANT-PERSON, fsToOrg:GRANT-ORG';
+
 const TRIALCO_AMT_LIMIT = 1000; // maximum payments received by a trial (dependent company) account
 //const TRIALCO_DAY_LIMIT = 14; // maximum number of days for a trial company
 const CREDIT_WITH_SSN = 200; // amount of initial creditline when SSN is verified

--- a/cgmembers/rcredits/forms/achbatch.inc
+++ b/cgmembers/rcredits/forms/achbatch.inc
@@ -72,7 +72,7 @@ function achBatch($args) {
   list ($recType, $priority, $recSize, $blocking, $format) = [1, 1, 94, 10, 1];
   $fileIdModifier = 'A'; // distinguishes files on the same date and between the same participants (A-Z, 0-9); never send two files on the same day, so this can be static
   $datetime = fmtDt(now(), 'yyMMddHHmm');
-  list ($originNum, $originName, $ref) = [CGF_EIN, $coName, ''];
+  list ($originNum, $originName, $ref) = [CGF_EIN, $way == 'OUT' ? $coNameCR : $coName, ''];
   $companyId = $coIdPrefix . CGF_EIN;
   
   $recs[] = achRecord(compact(array_keys($ray = ray(F_FILEHDR))), $ray);
@@ -137,7 +137,7 @@ X;
   if ($balance and $offset != 0) { // no need for an offset entry if file is already balanced or not supposed to be balanced
     list ($recType, $data, $addendaFlag) = [6, '', 0];
     list ($txCode, $routing, $account, $amount, $id, $name) // offset record parameters
-      = [$offset < 0 ? 22 : 27, $routing0, $acctIn, abs($offset), t('CTTYFUND OFFSET'), $coName];
+      = [$offset < 0 ? 22 : 27, $routing0, $acctIn, abs($offset), t('CTTYFUND OFFSET'), $originName];
     $count++;
     if ($offset <= 0) $credits -= $offset; else $debits += $offset;
     $hash += substr($routing, 0, 8);

--- a/cgmembers/rcredits/forms/cgpaygrants.inc
+++ b/cgmembers/rcredits/forms/cgpaygrants.inc
@@ -1,0 +1,128 @@
+<?php
+namespace CG\Web;
+use CG as r;
+use CG\Db as db;
+use CG\Util as u;
+
+/**
+ * @file
+ * Expected-grant CRUD endpoint for the SvelteKit cgpay POC.
+ *
+ * The POC's grants pages let a sponsored partner list and file an "expected
+ * grant" — a heads-up that a donor is sending funds. PHP owns the storage
+ * (`grants` table + grantor contact in `people` table) and the validation.
+ *
+ * Flow:
+ *   GET  /cgpay-grants?uid=<uid>   → list that user's expected grants
+ *   POST /cgpay-grants             → create a new expected grant
+ *
+ * Both require the same X-CG-Internal-Token shared secret used by /cgpay-sso
+ * and /cgpay-lookup (CGPAY_SSO_SECRET, see defs.inc). One secret for the whole
+ * server-to-server surface — no point splitting it.
+ *
+ * POST JSON body:
+ *   {
+ *     "uid":      <int>,            // sponsee account uid
+ *     "amount":   <decimal>,        // required, > 0
+ *     "by":       "ach"|"check"|"wire",  // required, payment method
+ *     "fullName": <string>,         // required, grantor name
+ *     "email":    <string?>, "phone": <string?>,
+ *     "address":  <string?>, "city": <string?>, "state": <int?>, "zip": <string?>
+ *   }
+ *
+ * Returns:
+ *   GET  200 {"grants": [{id, amount, by, grantor, documented, received, created}, ...]}
+ *   POST 200 {"id": <int>}
+ *   401  bad/missing shared secret
+ *   400  malformed input / failed validation (body: {"error": "<why>"})
+ *   404  uid does not resolve to an account
+ */
+function cgpayGrants() {
+  $method = nni($_SERVER, 'REQUEST_METHOD');
+  if (!in_array($method, ['GET', 'POST'])) return exitJust(X_SYNTAX);
+
+  $expected = CGPAY_SSO_SECRET;
+  $provided = nni($_SERVER, 'HTTP_X_CG_INTERNAL_TOKEN');
+  if (empty($expected) || empty($provided) || !hash_equals($expected, $provided)) {
+    return exitJust(X_UNAUTH);
+  }
+
+  return $method === 'GET' ? cgpayGrantsList() : cgpayGrantsCreate();
+}
+
+function cgpayGrantsList() {
+  $uid = (int) nni($_GET, 'uid');
+  if ($uid <= 0) return exitJust(X_SYNTAX);
+  $a = r\acct($uid);
+  if (!$a) return exitJust(X_NOTFOUND);
+  if (!$a->sponsored) return exitJust(X_FORBIDDEN);
+
+  $sql = "SELECT g.id, g.amount, g.by, g.documented, g.received, g.created, p.fullName AS grantor
+          FROM grants g LEFT JOIN people p USING(pid)
+          WHERE g.uid=:uid ORDER BY g.created DESC";
+  $rows = db\q($sql, compact('uid'))->fetchAll(\PDO::FETCH_ASSOC);
+
+  $grants = array_map(function($r) {
+    return [
+      'id'         => (int) $r['id'],
+      'amount'     => (float) $r['amount'],
+      'by'         => $r['by'],
+      'grantor'    => $r['grantor'] ?: '',
+      'documented' => $r['documented'] ? (int) $r['documented'] : null,
+      'received'   => $r['received'] ? (int) $r['received'] : null,
+      'created'    => (int) $r['created'],
+    ];
+  }, $rows);
+
+  return exitJson(['grants' => $grants], X_OK);
+}
+
+function cgpayGrantsCreate() {
+  $body = json_decode(file_get_contents('php://input'), TRUE);
+  if (!is_array($body)) return exitJust(X_SYNTAX);
+
+  $uid = (int) nni($body, 'uid');
+  if ($uid <= 0) return exitJust(X_SYNTAX);
+  $a = r\acct($uid);
+  if (!$a) return exitJust(X_NOTFOUND);
+  if (!$a->sponsored) return exitJust(X_FORBIDDEN);
+
+  $fullName = trim((string) nni($body, 'fullName'));
+  $amount   = nni($body, 'amount');
+  $by       = strtolower(trim((string) nni($body, 'by')));
+
+  if ($err = u\badName($fullName))      return exitJsonError($err);
+  if ($err = u\badAmount($amount, '>0')) return exitJsonError($err);
+  if (!in_array($by, ['ach', 'check', 'wire'], TRUE)) return exitJsonError('bad payment method');
+
+  $email   = trim((string) nni($body, 'email'));
+  $phone   = trim((string) nni($body, 'phone'));
+  $address = trim((string) nni($body, 'address'));
+  $city    = trim((string) nni($body, 'city'));
+  $state   = (int) nni($body, 'state');
+  $zip     = trim((string) nni($body, 'zip'));
+
+  if ($email !== '' && !u\validEmail($email)) return exitJsonError('bad email');
+  if ($phone !== '' && ($err = u\badPhone($phone))) return exitJsonError($err);
+  if ($zip !== ''   && ($err = u\badZip($zip)))    return exitJsonError($err);
+
+  $DBTX = \db_transaction();
+
+  $pid = db\updateOrInsert('people', compact(ray('fullName email phone address city state zip')), 'pid');
+
+  $id = db\insert('grants', [
+    'uid'     => $uid,
+    'pid'     => $pid,
+    'amount'  => $amount,
+    'by'      => $by,
+    'created' => now(),
+  ], 'id');
+
+  unset($DBTX);
+
+  return exitJson(['id' => (int) $id], X_OK);
+}
+
+function exitJsonError($msg) {
+  return exitJson(['error' => (string) $msg], X_SYNTAX);
+}

--- a/cgmembers/rcredits/forms/cgpaylookup.inc
+++ b/cgmembers/rcredits/forms/cgpaylookup.inc
@@ -1,0 +1,58 @@
+<?php
+namespace CG\Web;
+use CG as r;
+use CG\Db as db;
+use CG\Util as u;
+
+/**
+ * @file
+ * Identifier-lookup endpoint for the SvelteKit cgpay POC.
+ *
+ * The POC's login form lets the user type any of: account code (QID or short),
+ * username, full name (handled via shortName), email, or phone number. PHP owns
+ * the matching logic — r\loginString() already handles QID/short/email/name
+ * (including the encrypted-email path), and this endpoint extends it with phone.
+ *
+ * Flow:
+ *   POC POST /cgpay-lookup with X-CG-Internal-Token: <shared secret>
+ *     body: {"identifier": "<whatever the user typed>"}
+ *   This endpoint returns:
+ *     200 {"uid": <int>}  on match
+ *     401  on bad/missing shared secret
+ *     400  on missing identifier
+ *     404  on no match
+ *
+ * The POC then SELECTs `users.pass` by uid and verifies the password itself.
+ *
+ * Shared secret is the same one used by /cgpay-sso (CGPAY_SSO_SECRET, see
+ * defs.inc). One secret for both endpoints — no point splitting it.
+ */
+function cgpayLookup() {
+  if (nni($_SERVER, 'REQUEST_METHOD') !== 'POST') return exitJust(X_SYNTAX);
+
+  $expected = CGPAY_SSO_SECRET;
+  $provided = nni($_SERVER, 'HTTP_X_CG_INTERNAL_TOKEN');
+  if (empty($expected) || empty($provided) || !hash_equals($expected, $provided)) {
+    return exitJust(X_UNAUTH);
+  }
+
+  $body = json_decode(file_get_contents('php://input'), TRUE);
+  $identifier = isset($body['identifier']) ? trim((string) $body['identifier']) : '';
+  if ($identifier === '') return exitJust(X_SYNTAX);
+
+  // r\loginString covers: account code (QID + short code), email, and the
+  // username/short-name match — including the encrypted-email path.
+  $uid = r\loginString($identifier);
+
+  // Fallback: phone number. cgmembers' api.inc has phone matching but it's
+  // currently gated off (`FALSE and …`). We enable it here when r\loginString
+  // returns nothing AND the input looks phone-shaped.
+  if (!$uid && preg_match('/^[\+\(\)\.\- 0-9]{7,}$/', $identifier)) {
+    $phone = u\cry('P', u\fmtPhone($identifier, '+n'));
+    $uid = db\get('uid', 'users', 'phone=:phone ORDER BY :IS_CO', compact('phone'));
+  }
+
+  if (!$uid) return exitJust(X_NOTFOUND);
+
+  return exitJson(['uid' => (int) $uid], X_OK);
+}

--- a/cgmembers/rcredits/forms/cgpaysso.inc
+++ b/cgmembers/rcredits/forms/cgpaysso.inc
@@ -2,6 +2,7 @@
 namespace CG\Web;
 use CG as r;
 use CG\Db as db;
+use CG\Util as u;
 
 /**
  * @file
@@ -77,6 +78,25 @@ function cgpaySso() {
   // HTTPS-only sites.
   $cookieVal = session_id();
 
+  // Create a fresh `box-<QID>` device record + cookie. Acct::boxId() normally
+  // does this on a web signin, but its web-channel path reads the existing
+  // device code from $_COOKIE — which is empty on this server-to-server call.
+  // Inline the new-code path: generate a code, write the r_boxes row, return
+  // the cookie name and value so SvelteKit can forward it scoped to the shared
+  // parent domain alongside the SSESS cookie. Without this, downstream PHP
+  // features that look the device up in r_boxes don't recognise it.
+  $boxName = 'box-' . $a->mainQid;
+  $boxValue = u\code();
+  $boxnum = (db\get('MAX(boxnum)', 'r_boxes', ['uid' => $uid]) ?: 0) + 1;
+  db\insert('r_boxes', [
+    'uid' => $uid,
+    'code' => $boxValue,
+    'boxnum' => $boxnum,
+    'created' => now(),
+    'access' => now(),
+    'channel' => TX_WEB,
+  ]);
+
   // Menu categories for this user. Permission rules live in PHP (cg-menu.inc);
   // here we just expose top-level categories the cgpay dashboard renders as links.
   $menu = ['Dashboard', 'History', 'Community', 'Settings'];
@@ -84,9 +104,11 @@ function cgpaySso() {
   if ($a->can(B_ADMIN)) $menu[] = 'Admin';
 
   return exitJson([
-    'cookieName' => session_name(),
-    'sid'        => $cookieVal,
-    'ssid'       => $cookieVal,
-    'menu'       => $menu,
+    'cookieName'      => session_name(),
+    'sid'             => $cookieVal,
+    'ssid'            => $cookieVal,
+    'menu'            => $menu,
+    'boxCookieName'   => $boxName,
+    'boxCookieValue'  => $boxValue,
   ], X_OK);
 }

--- a/cgmembers/rcredits/forms/cgpaysso.inc
+++ b/cgmembers/rcredits/forms/cgpaysso.inc
@@ -51,23 +51,16 @@ function cgpaySso() {
   if (!$a) return exitJust(X_NOTFOUND);
   if (!$a->ok) return exitJust(X_FORBIDDEN);
 
-  // Fresh session IDs — distinct from the (ephemeral) session of THIS request.
-  $sid = drupal_random_key();
-  $ssid = drupal_random_key();
+  // Promote this request to the target user. setAcct() is what the regular
+  // signin form runs after a verified password (see forms/signin.inc). It
+  // updates the global $user, populates $_SESSION, and lets Drupal's
+  // _drupal_session_write() persist a real session row at end of request.
+  r\setAcct($uid, []);
 
-  // Direct INSERT — the codebase's db\insert() helper expects an 'id' primary-key
-  // column that this table doesn't have (sessions uses sid/ssid as the keys).
-  $row = [
-    'uid' => $uid,
-    'acct' => $uid,              // viewing own account
-    'sid' => $sid,
-    'ssid' => $ssid,
-    'hostname' => ip_address(),
-    'timestamp' => REQUEST_TIME,
-    'cache' => 0,
-    'session' => '',             // Drupal hydrates on the user's next request
-  ];
-  db\q('INSERT INTO sessions SET uid=:uid, acct=:acct, sid=:sid, ssid=:ssid, hostname=:hostname, timestamp=:timestamp, cache=:cache, session=:session', $row);
+  // session_id() now holds the value Drupal will write to sessions.ssid (and
+  // sessions.sid, since the site is HTTPS-only). That's what the browser will
+  // send back to the PHP host as the SSESS cookie.
+  $cookieVal = session_id();
 
   // Menu categories for this user. Permission rules live in PHP (cg-menu.inc);
   // here we just expose top-level categories the cgpay dashboard renders as links.
@@ -77,8 +70,8 @@ function cgpaySso() {
 
   return exitJson([
     'cookieName' => session_name(),
-    'sid'        => $sid,
-    'ssid'       => $ssid,
+    'sid'        => $cookieVal,
+    'ssid'       => $cookieVal,
     'menu'       => $menu,
   ], X_OK);
 }

--- a/cgmembers/rcredits/forms/cgpaysso.inc
+++ b/cgmembers/rcredits/forms/cgpaysso.inc
@@ -59,11 +59,18 @@ function cgpaySso() {
 
   // Promote this request to the target user. _drupal_session_write() at
   // shutdown reads $user->uid and writes that into the new sessions row, keyed
-  // by session_id(). A non-empty $_SESSION marks the session as "changed" so
-  // the write actually fires (otherwise short-circuits as anonymous-no-data).
+  // by session_id().
   global $user;
   $user = (object) ['uid' => $uid];
-  $_SESSION['cgpay_sso_login'] = REQUEST_TIME;
+
+  // Populate the session vars cgmembers bootstrap reads on the FOLLOWING request
+  // (when the browser arrives at the PHP site with our cookie). r\setAcct() with
+  // no args reads w\svar('myid') / w\svar('agentId') — which are stored as
+  // serialized values under the SVAR_HEADER ('rcredits_') prefix in $_SESSION
+  // (see rweb-subs.inc:svar). Without these, $mya is NULL and r\access() fails
+  // every permission check, so /history etc. redirect to the signin page.
+  $_SESSION[SVAR_HEADER . 'myid'] = serialize($uid);
+  $_SESSION[SVAR_HEADER . 'agentId'] = serialize($uid);
 
   // session_id() now holds the cookie value the browser will send back to demo
   // to authenticate as this user. Drupal writes it to both sid and ssid on

--- a/cgmembers/rcredits/forms/cgpaysso.inc
+++ b/cgmembers/rcredits/forms/cgpaysso.inc
@@ -1,0 +1,83 @@
+<?php
+namespace CG\Web;
+use CG as r;
+use CG\Db as db;
+
+/**
+ * @file
+ * Cross-app SSO endpoint for the SvelteKit cgpay POC.
+ *
+ * The cgpay POC (https://cgpay-poc.commongood.earth) verifies a user's password
+ * against `users.pass` and now also needs to sign that user in on the PHP side,
+ * so menu links from the dashboard can land on the existing member site without
+ * a second login. The flow:
+ *
+ *   1. Browser → POST /api/login on cgpay POC
+ *   2. cgpay POC verifies password (existing)
+ *   3. cgpay POC calls POST /cgpay-sso on this server (server-to-server)
+ *      with X-CG-Internal-Token: <shared secret> and JSON body {"uid": <int>}
+ *   4. This endpoint:
+ *        - verifies the shared secret
+ *        - creates a fresh row in `sessions` for that uid
+ *        - returns the cookie name + sid/ssid for the cgpay POC to forward
+ *   5. cgpay POC responds to the browser with Set-Cookie for that session,
+ *      scoped to Domain=.commongood.earth so the cookie reaches the PHP site
+ *
+ * Shared secret lives in config.json under key `cgpaySsoSecret`. It is rejected
+ * unless both ends present a non-empty matching value.
+ *
+ * This endpoint is NOT called from the browser — only from the cgpay server.
+ * No CORS headers, no session/login UI.
+ */
+function cgpaySso() {
+  if (nni($_SERVER, 'REQUEST_METHOD') !== 'POST') return exitJust(X_SYNTAX);
+
+  // Shared-secret auth. Refuse if config is missing — fail closed, not open.
+  $expected = config('cgpaySsoSecret');
+  $provided = nni($_SERVER, 'HTTP_X_CG_INTERNAL_TOKEN');
+  if (empty($expected) || empty($provided) || !hash_equals($expected, $provided)) {
+    return exitJust(X_UNAUTH);
+  }
+
+  // Parse JSON body
+  $raw = file_get_contents('php://input');
+  $body = json_decode($raw, TRUE);
+  $uid = isset($body['uid']) ? (int) $body['uid'] : 0;
+  if (!$uid) return exitJust(X_SYNTAX);
+
+  // Verify the target account exists and is allowed to use the system
+  $a = r\acct($uid);
+  if (!$a) return exitJust(X_NOTFOUND);
+  if (!$a->ok) return exitJust(X_FORBIDDEN);
+
+  // Fresh session IDs — distinct from the (ephemeral) session of THIS request.
+  $sid = drupal_random_key();
+  $ssid = drupal_random_key();
+
+  // Direct INSERT — the codebase's db\insert() helper expects an 'id' primary-key
+  // column that this table doesn't have (sessions uses sid/ssid as the keys).
+  $row = [
+    'uid' => $uid,
+    'acct' => $uid,              // viewing own account
+    'sid' => $sid,
+    'ssid' => $ssid,
+    'hostname' => ip_address(),
+    'timestamp' => REQUEST_TIME,
+    'cache' => 0,
+    'session' => '',             // Drupal hydrates on the user's next request
+  ];
+  db\q('INSERT INTO sessions SET uid=:uid, acct=:acct, sid=:sid, ssid=:ssid, hostname=:hostname, timestamp=:timestamp, cache=:cache, session=:session', $row);
+
+  // Menu categories for this user. Permission rules live in PHP (cg-menu.inc);
+  // here we just expose top-level categories the cgpay dashboard renders as links.
+  $menu = ['Dashboard', 'History', 'Community', 'Settings'];
+  if ($a->co) $menu[] = 'Company';
+  if ($a->can(B_ADMIN)) $menu[] = 'Admin';
+
+  return exitJson([
+    'cookieName' => session_name(),
+    'sid'        => $sid,
+    'ssid'       => $ssid,
+    'menu'       => $menu,
+  ], X_OK);
+}

--- a/cgmembers/rcredits/forms/cgpaysso.inc
+++ b/cgmembers/rcredits/forms/cgpaysso.inc
@@ -51,15 +51,23 @@ function cgpaySso() {
   if (!$a) return exitJust(X_NOTFOUND);
   if (!$a->ok) return exitJust(X_FORBIDDEN);
 
-  // Promote this request to the target user. setAcct() is what the regular
-  // signin form runs after a verified password (see forms/signin.inc). It
-  // updates the global $user, populates $_SESSION, and lets Drupal's
-  // _drupal_session_write() persist a real session row at end of request.
-  r\setAcct($uid, []);
+  // The SSO request itself came in without a session cookie, so Drupal never
+  // called session_start() at boot — meaning _drupal_session_write() won't fire
+  // automatically at shutdown. Start the session machinery now so the shutdown
+  // handler is wired up.
+  if (!drupal_session_started()) drupal_session_start();
 
-  // session_id() now holds the value Drupal will write to sessions.ssid (and
-  // sessions.sid, since the site is HTTPS-only). That's what the browser will
-  // send back to the PHP host as the SSESS cookie.
+  // Promote this request to the target user. _drupal_session_write() at
+  // shutdown reads $user->uid and writes that into the new sessions row, keyed
+  // by session_id(). A non-empty $_SESSION marks the session as "changed" so
+  // the write actually fires (otherwise short-circuits as anonymous-no-data).
+  global $user;
+  $user = (object) ['uid' => $uid];
+  $_SESSION['cgpay_sso_login'] = REQUEST_TIME;
+
+  // session_id() now holds the cookie value the browser will send back to demo
+  // to authenticate as this user. Drupal writes it to both sid and ssid on
+  // HTTPS-only sites.
   $cookieVal = session_id();
 
   // Menu categories for this user. Permission rules live in PHP (cg-menu.inc);

--- a/cgmembers/rcredits/forms/cgpaysso.inc
+++ b/cgmembers/rcredits/forms/cgpaysso.inc
@@ -23,8 +23,9 @@ use CG\Db as db;
  *   5. cgpay POC responds to the browser with Set-Cookie for that session,
  *      scoped to Domain=.commongood.earth so the cookie reaches the PHP site
  *
- * Shared secret lives in config.json under key `cgpaySsoSecret`. It is rejected
- * unless both ends present a non-empty matching value.
+ * Shared secret lives in config.json under key `cgpaySsoSecret` and is exposed at
+ * boot time as the CGPAY_SSO_SECRET constant (see defs.inc). It is rejected unless
+ * both ends present a non-empty matching value.
  *
  * This endpoint is NOT called from the browser — only from the cgpay server.
  * No CORS headers, no session/login UI.
@@ -33,7 +34,7 @@ function cgpaySso() {
   if (nni($_SERVER, 'REQUEST_METHOD') !== 'POST') return exitJust(X_SYNTAX);
 
   // Shared-secret auth. Refuse if config is missing — fail closed, not open.
-  $expected = config('cgpaySsoSecret');
+  $expected = CGPAY_SSO_SECRET;
   $provided = nni($_SERVER, 'HTTP_X_CG_INTERNAL_TOKEN');
   if (empty($expected) || empty($provided) || !hash_equals($expected, $provided)) {
     return exitJust(X_UNAUTH);

--- a/cgmembers/rcredits/forms/dashboard.inc
+++ b/cgmembers/rcredits/forms/dashboard.inc
@@ -19,7 +19,11 @@ function formDashboard($form, &$sta, $args = '') {
   extract(just('stay', $args, NULL));
 
   if ($mya->admSeeAccts and !$mya->proSe and !$stay) return go('/sadmin/summary'); // admins get way more info
-  
+
+  // Members land on the new SvelteKit POC dashboard when configured (see CGPAY_URL).
+  // /dashboard?stay=1 keeps the user on this PHP dashboard for fallback / debug.
+  if (CGPAY_URL and !$stay) return go(CGPAY_URL);
+
   $special = $endorse = $continue = NULL;
   
   if ($mya->ok and !$mya->co) {

--- a/cgmembers/rcredits/forms/pay.inc
+++ b/cgmembers/rcredits/forms/pay.inc
@@ -20,6 +20,7 @@ function formPay($form, &$sta, $args = NULL) {
 
   if ($code = nni($args, 'code')) { // customer clicked a coded button
     if (!$ray = getCGPayArgs($args, $mya) or !$coA = nni($ray, 'coA')) return; // error message already shown
+    if (!$coA->ok) return softErr('inactive');
     extract(just($codeFlds, $ray, NULL));
   } else { // vanilla CG donation page
     foreach (ray($codeFlds) as $k) $$k = NULL;

--- a/cgmembers/rcredits/forms/pay.inc
+++ b/cgmembers/rcredits/forms/pay.inc
@@ -20,7 +20,6 @@ function formPay($form, &$sta, $args = NULL) {
 
   if ($code = nni($args, 'code')) { // customer clicked a coded button
     if (!$ray = getCGPayArgs($args, $mya) or !$coA = nni($ray, 'coA')) return; // error message already shown
-    if (!$coA->ok) return softErr('inactive');
     extract(just($codeFlds, $ray, NULL));
   } else { // vanilla CG donation page
     foreach (ray($codeFlds) as $k) $$k = NULL;
@@ -311,6 +310,7 @@ function getCGPayArgs($args, $mya) {
 
   if ($expires and $expires < now()) return softErr(tr('button expired'));
   if (!$account or !$coA = r\acct($account)) return exitErr(t('That account does not exist.'));
+  if (!$coA->ok) return softErr('inactive');
   $coId = $coA->id;
   if ($mya and $mya->id == $coId) return softErr(t('Making a payment to yourself is not permitted.'));
   if (isset($s_amount) and $err = u\badAmount($s_amount, '>0')) return exitErr(t('Parameter "amount" (suggested amount): %err', compact('err')));

--- a/cgmembers/rcredits/forms/signup.inc
+++ b/cgmembers/rcredits/forms/signup.inc
@@ -101,7 +101,7 @@ function formSignup_validate($form, &$sta) {
   $err = u\badName($fullName); if ($err) return err($err, ['field' => 'fullName'], 'fullName');
   if (r\isCriminal($fullName, FALSE)) {
     r\tellAdmin(t('New potential member flagged as criminal'), $sta['input']);
-    return softErr(t('There is a problem with your account application. Please contact our support staff at %CGF_PHONE.'));
+    return softErr(t('code FLN'));
   }
   $fullName = u\normalizeCase($fullName);
 

--- a/cgmembers/rcredits/forms/signup.inc
+++ b/cgmembers/rcredits/forms/signup.inc
@@ -101,7 +101,7 @@ function formSignup_validate($form, &$sta) {
   $err = u\badName($fullName); if ($err) return err($err, ['field' => 'fullName'], 'fullName');
   if (r\isCriminal($fullName, FALSE)) {
     r\tellAdmin(t('New potential member flagged as criminal'), $sta['input']);
-    return softErr(t('code FLN'));
+    return softErr(tr('code FLN'));
   }
   $fullName = u\normalizeCase($fullName);
 

--- a/cgmembers/rcredits/forms/tx.inc
+++ b/cgmembers/rcredits/forms/tx.inc
@@ -13,7 +13,7 @@ use CG\Db as db;
 function formTx($form, &$sta, $type, $args = '') {
   extract(just('who amount goods purpose', $args, ''));
   global $mya;
-
+  
   $fbo = $mya->sponsored;
   $hasCats = r\hasCats($mya->uid) ?: 0;
 
@@ -73,7 +73,9 @@ function formTx($form, &$sta, $type, $args = '') {
   
   $admin = $mya->admNonmemberTx;
   list ($byDft, $byCheck) = [B_ACH, B_CHECK];
-  jsx('tx', compact(ray('field question selfErr payDesc chargeDesc fbo admin hasCats byDft byCheck')));
+  $porch = basename($_SERVER['REQUEST_URI']); // pay or charge (or dashboard, but that's going away soon)
+
+  jsx('tx', compact(ray('porch field question selfErr payDesc chargeDesc fbo admin hasCats byDft byCheck')));
   
   $paying = hidFld($pay);
   $hasCats = hidFld($hasCats);

--- a/cgmembers/rcredits/js/scraps.js
+++ b/cgmembers/rcredits/js/scraps.js
@@ -304,8 +304,9 @@ function doit(what, vs) {
     var pay;
     var purpose = $('#edit-purpose');
     var cat = $('#edit-cat');
-    $('.btn-pay, .btn-charge').click(function () {
-      pay = has($(this).attr('class'), 'btn-pay');
+
+    var porch = function () {
+      pay = vs['porch'] == 'dashboard' ? has($(this).attr('class'), 'btn-pay') : (vs['porch'] == 'pay');
       var desc = vs[pay ? 'payDesc' : 'chargeDesc'];
       $('#dashboard').hide();
       $('.w-pay').toggle(pay);
@@ -329,7 +330,10 @@ function doit(what, vs) {
       vs['restrict'] = pay ? ':IS_OK' : '';
       suggestWhoScrap();
       mem0Click(true);
-    });
+    };
+    
+    if (vs['porch'] == 'dashboard') $('.btn-pay, .btn-charge').click(porch); else porch();
+    
     if (vs['hasCats'] == 1) $('#edit-who').change(function () {
       var otherId = $('.whoId', $(this).parents('form:first'));
       if (purpose.val() == '' || cat.val() == '') post('suggestTxDesc', {

--- a/cgmembers/rcredits/misc/1096dump.php
+++ b/cgmembers/rcredits/misc/1096dump.php
@@ -4,6 +4,8 @@
  * Utility to list contents of FIRE-format forms 1099-NEC or 1099-K
  */
 
+$dumpflnm = 'E:\\Downloads\\dump.csv';
+
 if (!$flnm = @$_GET['flnm']) {
   echo <<<X
     <form>
@@ -19,6 +21,7 @@ $lines = explode("\r\n", $s);
 $i9 = count($lines) - (strpos($flnm, '1099K') ? 5 : 4);
 $flds = explode(', ', 'type:10:1, ein:11:9, qid:20:6, amt:54:12, nm:287:80, addr:367:80, city:447:40, st:487:2, zip:489:5');
 
+echo "<h2>See $dumpflnm for CSV. OR show source and copy to Notepad++ and thence to a tab in this year's audit spreadsheet.</h2>\n\n";
 $res[] = "ID\tamount\tname\taddress\tcity\tst\tzip";
 
 foreach ($lines as $i => $line) {
@@ -31,10 +34,10 @@ foreach ($lines as $i => $line) {
   foreach (explode(' ', 'nm addr city') as $k) $$k = ucwords(strtolower($$k));
   $type = $type == '1' ? '(co) ' : '';
   $amt = number_format($amt / 100, 2);
-  echo "$qid\t$$amt\t$nm, $addr, $city, $st $zip\n";
+  echo "$qid\t$$amt\t$nm\t$addr, $city, $st $zip\n";
   $res[] = "$qid\t$amt\t$nm\t$addr\t$city\t$st\t$zip";
 }
 
-file_put_contents('E:\\Downloads\\dump.csv', join("\n", $res));
+file_put_contents($dumpflnm, join("\n", $res));
 
 // end

--- a/cgmembers/rcredits/rcron/rcron.inc
+++ b/cgmembers/rcredits/rcron/rcron.inc
@@ -459,6 +459,7 @@ function adjustFS() {
     $nmSub = compact('nm');
     $donsToDate = db\sum('amt', 'txs_noreverse', ':IS_GIFT AND uid2=:uid', compact('uid'));
     if ($donsToDate <= 0) continue;
+
     if (!$ruleRow = db\row('tx_rules', "action=:ACT_SURTX AND payee=:uid AND purpose LIKE 'fiscal sponsorship fee%' AND `end` IS NULL", compact('uid'))) {$msgs[] = t('missing FS rule for ') . $nm; continue;}
     extract(just('id portion', $ruleRow)); $rule = $id;
     $feesCrit = compact(ray('uid rule'));
@@ -490,7 +491,7 @@ function adjustFS() {
     $msgs[] = t('adjusting FS fee for ') . $nm . ' ' . pr($info);
     db\update('tx_rules', ray('id portion purpose', $rule, round($rightPct/100, 4), $purpose), 'id');
     $cat = [r\nick2cat('D-FBO'), r\nick2cat('FS-FEE')];
-    r\acct($uid)->payApproved(CGID, $offBy, t('fiscal sponsorship fee adjustment'), FOR_GOODS, compact(ray('rule cat')));
+    r\acct($uid)->payApproved(CGID, $offBy, tr('fs fee adjust'), FOR_GOODS, compact(ray('rule cat')));
   }
 
   if ($msg = join("\n", nn($msgs, []))) {
@@ -507,16 +508,16 @@ function adjustFS() {
  * @return [$fee, $pct]: the expected fee total and correct percentage going forward
  */
 function fsFee($dons, $fee1pct) {
-  $CK = 100000;
+  $CK = 100000; // rate adjusts with every $100k (chunk) of donations
   $pct = $fee1pct;
   $fee = 0;
   
-  while ($dons > $CK) {
-    $fee += $CK * $pct / 100;
+  while ($dons > $CK and $pct > $fee1pct - FS_FEE_SPREAD) {
+    $fee += $CK * $pct / 100; // original pct of first chunk, 0.5% less for next chunk, etc.
     $dons -= $CK;
     $pct -= 0.5;
   }
-  $fee += $dons * $pct / 100;
+  $fee += $dons * $pct / 100; // add current percentage of donations beyond the most recent change point
   $fee = round($fee, 2);
 
   return [$fee, $pct];

--- a/cgmembers/rcredits/rweb/features/ccpay.feature
+++ b/cgmembers/rcredits/rweb/features/ccpay.feature
@@ -21,6 +21,16 @@ Setup:
   | .ZZB |       0 |
   | .ZZC |       0 |
 
+Scenario: A non-member clicks a link to donate to a closed account
+  Given button code "buttonCode" for:
+  | account | secret | for    |*
+  | .ZZC    | Cc3    | donate |
+  And members have:
+  | uid  | flags               |*
+  | .ZZC | member,co,confirmed |
+  When member "?" visits "pay/code=%buttonCode"
+  Then we say "error": "inactive"
+  
 Scenario: A non-member clicks a link to donate to a ccOk organization by Stripe
   Given button code "buttonCode" for:
   | account | secret | for    |*

--- a/cgmembers/rcredits/rweb/features/cgpay.feature
+++ b/cgmembers/rcredits/rweb/features/cgpay.feature
@@ -31,7 +31,17 @@ Scenario: A member clicks an expired pay button
   | .ZZC    | Cc3    | food | 23.50  | %now-1d |
   When member "?" visits page "pay/code=%buttonCode"
   Then we say "error": "button expired"
-
+  
+Scenario: A member clicks a pay button for a closed account
+  Given button code "buttonCode" for:
+  | account | secret | item | amount | expires |*
+  | .ZZC    | Cc3    | food | 23.50  |         |
+  And members have:
+  | uid  | flags               |*
+  | .ZZC | member,co,confirmed |
+  When member "?" visits page "pay/code=%buttonCode"
+  Then we say "error": "inactive"
+  
 Scenario: A member submits a pay button payment with account ID
   Given button code "buttonCode" for:
   | account | secret | item | amount |*

--- a/cgmembers/rcredits/rweb/features/fbo.feature
+++ b/cgmembers/rcredits/rweb/features/fbo.feature
@@ -418,3 +418,36 @@ Scenario: a sponsored organization moves credit to the bank
   And we message "banked" to member ".ZZC" with subs:
   | action  | tofrom | amount | why             |*
   | deposit | to     | $86    | as soon as possible |
+
+Scenario: Fiscal sponsorship fees are not adjusted
+  Given these "txs":
+  | eid | xid | payer | payee | amount | purpose | cat2   | type     | agt2 | flags | rule |*
+  | 1   | 1   | .ZZA  | .ZZC  | 100000 | grant   | D-FBO  | %E_PRIME | .ZZA | gift  |      |
+  | 2   | 1   | .ZZC  | cgf   | 5000   | 5%fsfee | FS-FEE | %E_AUX   | .ZZC | gift  | 1    |
+  When cron runs "adjustFS"
+  Then these "tx_rules":
+  | id        | 1            |**
+  | portion   | .05          |
+
+Scenario: Fiscal sponsorship fees are adjusted
+  Given these "txs":
+  | eid | xid | payer | payee | amount | purpose | cat2   | type     | agt2 | flags | rule |*
+  | 1   | 1   | .ZZA  | .ZZC  | 110000 | grant   | D-FBO  | %E_PRIME | .ZZA | gift  |      |
+  | 2   | 1   | .ZZC  | cgf   | 5500   | 5%fsfee | FS-FEE | %E_AUX   | .ZZC | gift  | 1    |
+  When cron runs "adjustFS"
+  Then these "tx_rules":
+  | id        | 1            |**
+  | portion   | .045         |
+  And these "txs":
+  | xid | payer | payee | amount | purpose       | rule |*
+  | 2   | .ZZC  | cgf   | -50    | fs fee adjust | 1    |
+
+Scenario: Fiscal sponsorship fees have a minimum
+  Given these "txs":
+  | eid | xid | payer | payee | amount  | purpose | cat2   | type     | agt2 | flags | rule |*
+  | 1   | 1   | .ZZA  | .ZZC  | 9999999 | grant   | D-FBO  | %E_PRIME | .ZZA | gift  |      |
+  | 2   | 1   | .ZZC  | cgf   | 250000  | 5%fsfee | FS-FEE | %E_AUX   | .ZZC | gift  | 1    |
+  When cron runs "adjustFS"
+  Then these "tx_rules":
+  | id        | 1                        |**
+  | portion   | %(.05-FS_FEE_SPREAD/100) |

--- a/cgmembers/rcredits/rweb/features/signup.feature
+++ b/cgmembers/rcredits/rweb/features/signup.feature
@@ -312,3 +312,12 @@ Scenario: A member registers again
   Then we say "error": "duplicate email|forgot password" with subs:
   | a                                          |*
   | a href="settings/password/a%40example.com" |
+
+Scenario: A member registers with criminal name
+  Given these "ofac":
+  | nm    | co |*
+  | chris | 0  |
+  When member "?" confirms form "signup" with values:
+  | fullName | email | phone        |  zip  | acctType     | cq | ca |*
+  | Chris    | c@    | 413-253-0000 | 01002 | %CO_PERSONAL | 37 | 74 |
+  Then we say "error": "code FLN"

--- a/cgmembers/rcredits/rweb/queries.inc
+++ b/cgmembers/rcredits/rweb/queries.inc
@@ -15,10 +15,11 @@ use CG\Util as u;
  */
 
 global $mya;
+const FSCATMAP = 'fsFeeCat:FS-FEE, fsInCat:D-FBO, stepupCat:D-STEPUP, fsStepupCat:D-FBO-STEPUP, fsOutCat1:FIRST-FS-EXPENSE, fsOutCat9:LAST-FS-EXPENSE, fsToPerson:GRANT-PERSON, fsToOrg:GRANT-ORG';
 
 $bizQ = 'SELECT uid as payee, goods, SUM(IF(amount>0,amount,0)) AS sales, SUM(IF(amount<0,amount,0)) AS payments, COUNT(*) AS cnt FROM tx_entries JOIN tx_hdrs USING (xid) WHERE goods=:FOR_GOODS AND created BETWEEN';
 $gifts = r\annualAmt();
-$fsFeeCat = r\nick2cat('FS-FEE');
+foreach (ray(FSCATMAP) as $cat => $nick) $$cat = r\nick2cat($nick);
 
 if ($mya and $mya->admin) {
   $source = "TRIM(REPLACE(REPLACE(source,'knows: self ()', ''), '-', ' '))";
@@ -107,20 +108,22 @@ if ($mya and $mya->admin) {
       
   1 . t('Fiscal Sponsorships Last FY') =>
     "SELECT LEFT(FROM_UNIXTIME(u.created), 10) AS Since, fullName AS Partner, CONCAT(city, ', ', abbreviation) AS Location,
-      IF(ru.portion IS NULL, '', CONCAT(100*ru.portion, '%')) AS Fee, x2.outLastFY AS ExpenseLastFY, x1.inLastFY AS GiftsLastFY, Mission
+      IF(ru.portion IS NULL, '', CONCAT(100*ru.portion, '%')) AS Fee, x2.outLastFY AS ExpenseLastFY, x2.grantsOutLastFY AS GrantsLastFY, x1.inLastFY AS GiftsLastFY, Mission
       FROM users u 
       LEFT JOIN u_company c USING (uid) 
       LEFT JOIN r_states s ON s.id=u.state
       LEFT JOIN tx_rules ru ON ru.payee=u.uid
       LEFT JOIN (
-        SELECT uid2 AS uid, SUM(amt) AS inLastFY
+        SELECT uid2 AS uid, cat2, SUM(amt) AS inLastFY
         FROM txs t WHERE t.created BETWEEN $fy0 AND $fy9 AND uid1<>:UID_BANK GROUP BY uid
       ) x1 USING(uid)
       LEFT JOIN (
-        SELECT IF(uid1=:UID_BANK, uid2, uid1) AS uid, SUM(IF(uid1=:UID_BANK, -amt, amt)) AS outLastFY
+        SELECT IF(uid1=:UID_BANK, uid2, uid1) AS uid, cat1, SUM(IF(uid1=:UID_BANK, -amt, amt)) AS outLastFY,
+          SUM(IF(cat1 IN ($fsToPerson, $fsToOrg), amt, 0)) AS grantsOutLastFY
         FROM txs t WHERE t.created BETWEEN $fy0 AND $fy9 AND uid2<>:CGID GROUP BY uid
       ) x2 USING(uid)
-      WHERE u.:IS_OK AND (coFlags & (1<<:CO_SPONSORED) OR uid=:CGID) ORDER BY x2.outLastFY DESC, u.fullName",
+      WHERE (x1.cat2 IN ($fsInCat, $fsStepupCat, $stepupCat) OR x2.cat1 BETWEEN $fsOutCat1 AND $fsOutCat9 OR uid=:CGID) ORDER BY x2.outLastFY DESC, u.fullName",
+//      WHERE u.:IS_OK AND (coFlags & (1<<:CO_SPONSORED) OR uid=:CGID) ORDER BY x2.outLastFY DESC, u.fullName",
   
   1 . t('1099K') . $fyDesc =>
     "SELECT u.mainQid! AS ID, FORMAT(SUM(x.amt), 2) AS amount, u.fullName as name, u.postalAddr!

--- a/cgmembers/rcredits/rweb/queries.inc
+++ b/cgmembers/rcredits/rweb/queries.inc
@@ -15,7 +15,6 @@ use CG\Util as u;
  */
 
 global $mya;
-const FSCATMAP = 'fsFeeCat:FS-FEE, fsInCat:D-FBO, stepupCat:D-STEPUP, fsStepupCat:D-FBO-STEPUP, fsOutCat1:FIRST-FS-EXPENSE, fsOutCat9:LAST-FS-EXPENSE, fsToPerson:GRANT-PERSON, fsToOrg:GRANT-ORG';
 
 $bizQ = 'SELECT uid as payee, goods, SUM(IF(amount>0,amount,0)) AS sales, SUM(IF(amount<0,amount,0)) AS payments, COUNT(*) AS cnt FROM tx_entries JOIN tx_hdrs USING (xid) WHERE goods=:FOR_GOODS AND created BETWEEN';
 $gifts = r\annualAmt();

--- a/cgmembers/rcredits/rweb/rweb.steps
+++ b/cgmembers/rcredits/rweb/rweb.steps
@@ -1214,6 +1214,9 @@ function agentCardCodeIs($id, $cardCode2) {
  *
  * in: MAKE community CronCalculatesTheStatistics
  *     MAKE dashboard Setup
+ *     MAKE fbo FiscalSponsorshipFeesAreNotAdjusted
+ *     MAKE fbo FiscalSponsorshipFeesAreAdjusted
+ *     MAKE fbo FiscalSponsorshipFeesHaveAMinimum
  *     MAKE joint AJoinedAccountMemberLooksAtTransactionHistoryAndSummary
  */
 function cronRuns($op) {return t\cronRuns($op);}
@@ -1791,6 +1794,9 @@ function weScripWithSubs($script, $args = []) {
  *     TEST fbo AMemberDonatesToASponsoredOrganization
  *     TEST fbo AMemberPaysASponsoredOrganization
  *     TEST fbo ASponsoredOrganizationMovesCreditToTheBank
+ *     BOTH fbo FiscalSponsorshipFeesAreNotAdjusted
+ *     BOTH fbo FiscalSponsorshipFeesAreAdjusted
+ *     BOTH fbo FiscalSponsorshipFeesHaveAMinimum
  *     MAKE flow Setup
  *     TEST flow AMemberDraws
  *     TEST flow AJointAccountSlaveMemberDraws

--- a/cgmembers/rcredits/rweb/rweb.steps
+++ b/cgmembers/rcredits/rweb/rweb.steps
@@ -179,6 +179,7 @@ function memberCompletesFormWithValues($id, $page, $values) {return t\completeFo
  *     MAKE signup AMemberRegistersBadEmail
  *     MAKE signup AMemberRegistersBadZip
  *     MAKE signup AMemberRegistersAgain
+ *     MAKE signup AMemberRegistersWithCriminalName
  *     MAKE stepup AMembersRulesComeIntoPlay
  *     MAKE stepup ASurtxAmountRoundsToZero
  *     MAKE stepup CommonGoodGetsAStepupDonation
@@ -475,6 +476,7 @@ function weSayWithSubs($type, $index, $subs) {return t\weSayWithSubs($type, $ind
  *     TEST signup AMemberChoosesProxies
  *     TEST signup AMemberRegistersBadEmail
  *     TEST signup AMemberRegistersBadZip
+ *     TEST signup AMemberRegistersWithCriminalName
  *     TEST sponsor ANonmemberAppliesForFiscalSponsorship
  *     TEST sponsor ASignedinIndividualMemberAppliesForFiscalSponsorship
  *     TEST sponsor ASignedinCompanyAppliesForFiscalSponsorshipWithoutManagePermission
@@ -1881,6 +1883,7 @@ function weScripWithSubs($script, $args = []) {
  *     TEST signup AMemberSetsCalling
  *     TEST signup AMemberInvites
  *     MAKE signup AMemberChoosesProxies
+ *     MAKE signup AMemberRegistersWithCriminalName
  *     MAKE sponsor Setup
  *     MAKE sponsor AFiscallySponsoredApplicantUpdatesItsSettings
  *     MAKE statement Setup

--- a/cgmembers/rcredits/rweb/rweb.steps
+++ b/cgmembers/rcredits/rweb/rweb.steps
@@ -405,7 +405,9 @@ function weSayWithSubs($type, $index, $subs) {return t\weSayWithSubs($type, $ind
  *
  * in: TEST bank AMemberMovesTooLittleToTheBank
  *     TEST bank AMemberTriesToGoBelowTheirMinimum
+ *     TEST ccpay ANonmemberClicksALinkToDonateToAClosedAccount
  *     TEST cgpay AMemberClicksAnExpiredPayButton
+ *     TEST cgpay AMemberClicksAPayButtonForAClosedAccount
  *     TEST company AMemberUpdatesCompanyInfo
  *     TEST connect AnActiveMemberConnectsABankAccountWithABadRoutingNumber
  *     TEST contact AMemberUpdatesContactInfo
@@ -879,6 +881,7 @@ function balances($list) {return t\balances($list);}
  *     MAKE bank AMemberRequestsMoreThanTheTotalTheBankAllowsInOneDay
  *     MAKE cgpay AMemberClicksAPayButton
  *     MAKE cgpay AMemberClicksAnExpiredPayButton
+ *     MAKE cgpay AMemberClicksAPayButtonForAClosedAccount
  *     MAKE cgpay AMemberClicksAPayButtonWithVariableAmount
  *     MAKE cgpay AMemberClicksAButtonToBuyStoreCredit
  *     MAKE cgpay AMemberClicksAButtonToBuyStoreCreditForADifferentAmount
@@ -1238,10 +1241,12 @@ function statisticsGetSet($time) {
  * in: MAKE backing AMemberDecreasesBackingAmount
  *     MAKE bank ASlaveMemberRequestsATransfer
  *     MAKE boxes AMemberTransactsAndBoxIdGetsRecorded
+ *     MAKE ccpay ANonmemberClicksALinkToDonateToAClosedAccount
  *     MAKE ccpay ANonmemberClicksALinkToDonateToAnUnauthorizedOrganization
  *     MAKE ccpay ANonmemberConfirmsADonationToASponsoredOrganizationByCreditCard
  *     MAKE ccpay ANonmemberConfirmsAPaymentToACcOkOrganizationByCreditCard
  *     MAKE ccpay AMemberDonatesToACcOkOrganization
+ *     MAKE cgpay AMemberClicksAPayButtonForAClosedAccount
  *     MAKE cgpay AMemberRedeemsStoreCreditOverspendingAZeroBalance
  *     MAKE coupons AMemberCompanyCreatesAGiftCoupon
  *     BOTH coupons AMemberRedeemsAGiftCoupon
@@ -2444,7 +2449,8 @@ function memberAjaxWith($id, $op, $ray) {
 /**
  * member (ARG) visits (ARG)
  *
- * in: MAKE ccpay ANonmemberClicksALinkToDonateToACcOkOrganizationByStripe
+ * in: MAKE ccpay ANonmemberClicksALinkToDonateToAClosedAccount
+ *     MAKE ccpay ANonmemberClicksALinkToDonateToACcOkOrganizationByStripe
  *     MAKE ccpay ANonmemberClicksALinkToDonateToAnUnauthorizedOrganization
  *     MAKE ccpay ANonmemberClicksALinkToPayACcOkOrganizationByStripe
  *     MAKE fbo ANonmemberDonatesToASponsoredMemberByCheck
@@ -2622,12 +2628,14 @@ function weShowPDFWith($list) {return t\pdfHas($list);}
  * button code (ARG) for: (ARG)
  *
  * in: MAKE accredit AMemberTriesToBuyCreditWithCredit
+ *     MAKE ccpay ANonmemberClicksALinkToDonateToAClosedAccount
  *     MAKE ccpay ANonmemberClicksALinkToDonateToACcOkOrganizationByStripe
  *     MAKE ccpay ANonmemberClicksALinkToDonateToAnUnauthorizedOrganization
  *     MAKE ccpay ANonmemberClicksALinkToPayACcOkOrganizationByStripe
  *     MAKE ccpay AMemberDonatesToACcOkOrganization
  *     MAKE cgpay AMemberClicksAPayButton
  *     MAKE cgpay AMemberClicksAnExpiredPayButton
+ *     MAKE cgpay AMemberClicksAPayButtonForAClosedAccount
  *     MAKE cgpay AMemberSubmitsAPayButtonPaymentWithAccountID
  *     MAKE cgpay AMemberClicksAPayButtonWithVariableAmount
  *     MAKE cgpay AMemberSubmitsAPayButtonPaymentWithAccountIDAndChosenAmount

--- a/db/migrations/20260518054016_f_s_expense_markers.php
+++ b/db/migrations/20260518054016_f_s_expense_markers.php
@@ -1,0 +1,18 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+use Phinx\Db\Adapter\MysqlAdapter as phx;
+
+require_once __DIR__ . '/util.inc';
+
+class FSExpenseMarkers extends AbstractMigration {
+  public function up(): void {
+    $catNicks = ['E: Sponsored Project Expenses' => 'FIRST-FS-EXPENSE', 'E: Sponsored Project Expenses: Travel' => 'LAST-FS-EXPENSE'];
+    foreach ($catNicks as $cat => $nick) $this->doSql("UPDATE tx_cats SET nick='$nick' WHERE category='$cat'");
+  }
+
+  public function down(): void {
+    throw new \RuntimeException('This migration is not reversible.');
+  }
+  public function doSql($sql) {cgpr("$sql\n"); $this->execute($sql);}
+}


### PR DESCRIPTION
A company's CGPay buttons continue to allow customers or donors to transfer money to the company's account after the account is closed/inactive. Not good. This branch fixes it and tests the fix.