### PR TITLE
feat(grants): /cgpay-grants PATCH + fund column + /cgpay-people-autocomplete endpoint

### DIFF
--- a/cgmembers/rcredits/cg-menu.inc
+++ b/cgmembers/rcredits/cg-menu.inc
@@ -249,7 +249,8 @@ function menu($submenu = '') {
     'api' => ['call', 'API', '1', ANY, 'api'],
     'cgpay-sso' => ['call', 'CGPay SSO', '', ANY, 'cgpaySso'], // server-to-server: SvelteKit cgpay POC handing off a verified login to PHP
     'cgpay-lookup' => ['call', 'CGPay Lookup', '', ANY, 'cgpayLookup'], // server-to-server: SvelteKit cgpay POC identifier (qid/name/email/phone) -> uid resolution
-    'cgpay-grants' => ['call', 'CGPay Grants', '', ANY, 'cgpayGrants'], // server-to-server: SvelteKit cgpay POC expected-grant list + create
+    'cgpay-grants' => ['call', 'CGPay Grants', '', ANY, 'cgpayGrants'], // server-to-server: SvelteKit cgpay POC expected-grant list + create + update
+    'cgpay-people-autocomplete' => ['call', 'CGPay People Autocomplete', '', ANY, 'cgpayPeopleAutocomplete'], // server-to-server: SvelteKit cgpay POC grantor autocomplete
     'cc' => ['call', 'Credit Card Donation', 'Pay 1', ANY],
     'donate-fbo' => ['call', t('Donate'), 'Pay 1', ANY], // deprecated (use donate instead), but still used by Kibilio as of 11/22/2021
   );

--- a/cgmembers/rcredits/cg-strings.inc
+++ b/cgmembers/rcredits/cg-strings.inc
@@ -276,7 +276,8 @@ EOF
   'fs fee adjust' => t('fiscal sponsorship fee adjustment'),
   'sponsee notified' => t('The sponsee has been notified that this grant was received, but needs documentation.'),
   'grantdoc-required' => t('Your %amt grant from %grantorName has been received, but needs documentation before the funds can be released to your account. At your convenience, please email a copy of the grant agreement to %PROJECT at %CGF_EMAIL. Then sign in to your account and on the Company menu choose "Grants Expected" to enter the date you emailed us the agreement.'),
-    
+  'grantor-contact-changed' => t('Sponsee (uid %sponsee) changed contact info for grantor "%grantor" — fields updated: %fields.'),
+
   // prompts
   'note' => '<b class="loud">' . t('NOTE:') . '</b>',
   'legalname desc' => t(' full legal name, properly capitalized, for tax reporting and banking.'),

--- a/cgmembers/rcredits/forms/cgpaygrants.inc
+++ b/cgmembers/rcredits/forms/cgpaygrants.inc
@@ -8,38 +8,52 @@ use CG\Util as u;
  * @file
  * Expected-grant CRUD endpoint for the SvelteKit cgpay POC.
  *
- * The POC's grants pages let a sponsored partner list and file an "expected
- * grant" — a heads-up that a donor is sending funds. PHP owns the storage
- * (`grants` table + grantor contact in `people` table) and the validation.
+ * The POC's grants pages let a sponsored partner list, file, and edit an
+ * "expected grant" — a heads-up that a donor is sending funds. PHP owns the
+ * storage (`grants` table + grantor contact in `people` table) and validation.
  *
  * Flow:
- *   GET  /cgpay-grants?uid=<uid>   → list that user's expected grants
- *   POST /cgpay-grants             → create a new expected grant
+ *   GET   /cgpay-grants?uid=<uid>   → list that user's expected grants
+ *   POST  /cgpay-grants             → create a new expected grant
+ *   PATCH /cgpay-grants             → update an existing expected grant
  *
- * Both require the same X-CG-Internal-Token shared secret used by /cgpay-sso
- * and /cgpay-lookup (CGPAY_SSO_SECRET, see defs.inc). One secret for the whole
- * server-to-server surface — no point splitting it.
+ * All require the same X-CG-Internal-Token shared secret used by /cgpay-sso
+ * and /cgpay-lookup (CGPAY_SSO_SECRET, see defs.inc).
  *
- * POST JSON body:
+ * POST JSON body (create):
  *   {
- *     "uid":      <int>,            // sponsee account uid
- *     "amount":   <decimal>,        // required, > 0
- *     "by":       "ach"|"check"|"wire",  // required, payment method
- *     "fullName": <string>,         // required, grantor name
+ *     "uid":      <int>,                       // sponsee account uid
+ *     "amount":   <decimal>,                   // required, > 0
+ *     "by":       "ach"|"check"|"wire",        // required, payment method
+ *     "fund":     <string?>,                   // specific fund within a grant-making organization
+ *     "grantorPid": <int?>,                    // if grantor was picked from autocomplete
+ *     "fullName": <string>,                    // required, grantor name
  *     "email":    <string?>, "phone": <string?>,
  *     "address":  <string?>, "city": <string?>, "state": <int?>, "zip": <string?>
  *   }
  *
+ * PATCH JSON body (update):
+ *   { "uid": <int>, "id": <int>, ...same fields... }
+ *   All grant + grantor fields optional; only the provided ones change.
+ *
+ * Grantor-resolution rules (per William):
+ *   - No grantorPid provided or pid unknown → new people row
+ *   - grantorPid matches, fullName unchanged, missing field being filled → silent update
+ *   - grantorPid matches, fullName unchanged, existing field being changed → update people row,
+ *     log old→new to changes table, alert admin
+ *   - grantorPid matches, fullName changed → new people row (treat as different entity)
+ *
  * Returns:
- *   GET  200 {"grants": [{id, amount, by, grantor, documented, received, created}, ...]}
- *   POST 200 {"id": <int>}
- *   401  bad/missing shared secret
- *   400  malformed input / failed validation (body: {"error": "<why>"})
- *   404  uid does not resolve to an account
+ *   GET   200 {"grants": [{id, amount, by, fund, grantor, documented, received, created}, ...]}
+ *   POST  200 {"id": <int>}
+ *   PATCH 200 {"id": <int>}
+ *   401   bad/missing shared secret
+ *   400   malformed input / failed validation (body: {"error": "<why>"})
+ *   404   uid/id does not resolve
  */
 function cgpayGrants() {
   $method = nni($_SERVER, 'REQUEST_METHOD');
-  if (!in_array($method, ['GET', 'POST'])) return exitJust(X_SYNTAX);
+  if (!in_array($method, ['GET', 'POST', 'PATCH'])) return exitJust(X_SYNTAX);
 
   $expected = CGPAY_SSO_SECRET;
   $provided = nni($_SERVER, 'HTTP_X_CG_INTERNAL_TOKEN');
@@ -47,7 +61,9 @@ function cgpayGrants() {
     return exitJust(X_UNAUTH);
   }
 
-  return $method === 'GET' ? cgpayGrantsList() : cgpayGrantsCreate();
+  if ($method === 'GET')   return cgpayGrantsList();
+  if ($method === 'POST')  return cgpayGrantsCreate();
+  return cgpayGrantsUpdate();
 }
 
 function cgpayGrantsList() {
@@ -57,7 +73,7 @@ function cgpayGrantsList() {
   if (!$a) return exitJust(X_NOTFOUND);
   if (!$a->sponsored) return exitJust(X_FORBIDDEN);
 
-  $sql = "SELECT g.id, g.amount, g.by, g.documented, g.received, g.created, p.fullName AS grantor
+  $sql = "SELECT g.id, g.amount, g.by, g.fund, g.documented, g.received, g.created, g.pid, p.fullName AS grantor
           FROM grants g LEFT JOIN people p USING(pid)
           WHERE g.uid=:uid ORDER BY g.created DESC";
   $rows = db\q($sql, compact('uid'))->fetchAll(\PDO::FETCH_ASSOC);
@@ -67,6 +83,8 @@ function cgpayGrantsList() {
       'id'         => (int) $r['id'],
       'amount'     => (float) $r['amount'],
       'by'         => $r['by'],
+      'fund'       => $r['fund'] ?: '',
+      'grantorPid' => $r['pid'] ? (int) $r['pid'] : null,
       'grantor'    => $r['grantor'] ?: '',
       'documented' => $r['documented'] ? (int) $r['documented'] : null,
       'received'   => $r['received'] ? (int) $r['received'] : null,
@@ -87,40 +105,172 @@ function cgpayGrantsCreate() {
   if (!$a) return exitJust(X_NOTFOUND);
   if (!$a->sponsored) return exitJust(X_FORBIDDEN);
 
-  $fullName = trim((string) nni($body, 'fullName'));
-  $amount   = nni($body, 'amount');
-  $by       = strtolower(trim((string) nni($body, 'by')));
-
-  if ($err = u\badName($fullName))      return exitJsonError($err);
-  if ($err = u\badAmount($amount, '>0')) return exitJsonError($err);
-  if (!in_array($by, ['ach', 'check', 'wire'], TRUE)) return exitJsonError('bad payment method');
-
-  $email   = trim((string) nni($body, 'email'));
-  $phone   = trim((string) nni($body, 'phone'));
-  $address = trim((string) nni($body, 'address'));
-  $city    = trim((string) nni($body, 'city'));
-  $state   = (int) nni($body, 'state');
-  $zip     = trim((string) nni($body, 'zip'));
-
-  if ($email !== '' && !u\validEmail($email)) return exitJsonError('bad email');
-  if ($phone !== '' && ($err = u\badPhone($phone))) return exitJsonError($err);
-  if ($zip !== ''   && ($err = u\badZip($zip)))    return exitJsonError($err);
+  $grantFlds = cgpayGrantsParseFlds($body, TRUE);
+  if (is_string($grantFlds)) return exitJsonError($grantFlds);
 
   $DBTX = \db_transaction();
 
-  $pid = db\updateOrInsert('people', compact(ray('fullName email phone address city state zip')), 'pid');
+  $pid = cgpayGrantsResolveGrantorPid($body, $uid);
+  if (is_string($pid)) return exitJsonError($pid);
 
-  $id = db\insert('grants', [
+  $id = db\insert('grants', $grantFlds + [
     'uid'     => $uid,
     'pid'     => $pid,
-    'amount'  => $amount,
-    'by'      => $by,
     'created' => now(),
   ], 'id');
 
   unset($DBTX);
 
   return exitJson(['id' => (int) $id], X_OK);
+}
+
+function cgpayGrantsUpdate() {
+  $body = json_decode(file_get_contents('php://input'), TRUE);
+  if (!is_array($body)) return exitJust(X_SYNTAX);
+
+  $uid = (int) nni($body, 'uid');
+  $id  = (int) nni($body, 'id');
+  if ($uid <= 0 || $id <= 0) return exitJust(X_SYNTAX);
+  $a = r\acct($uid);
+  if (!$a) return exitJust(X_NOTFOUND);
+  if (!$a->sponsored) return exitJust(X_FORBIDDEN);
+
+  $existing = db\row('grants', compact('id'));
+  if (!$existing || (int) $existing->uid !== $uid) return exitJust(X_NOTFOUND);
+
+  $grantFlds = cgpayGrantsParseFlds($body, FALSE);
+  if (is_string($grantFlds)) return exitJsonError($grantFlds);
+
+  $DBTX = \db_transaction();
+
+  if (cgpayGrantsHasGrantorInput($body)) {
+    $pid = cgpayGrantsResolveGrantorPid($body, $uid, (int) $existing->pid);
+    if (is_string($pid)) return exitJsonError($pid);
+    $grantFlds['pid'] = $pid;
+  }
+
+  if ($grantFlds) db\update('grants', compact('id') + $grantFlds, 'id');
+
+  unset($DBTX);
+
+  return exitJson(['id' => $id], X_OK);
+}
+
+/**
+ * Parse grant-row fields (amount, by, fund) from the request body.
+ * @param bool $required  TRUE for create (amount + by required), FALSE for update (all optional).
+ * @return array|string   Fields to persist, or an error message string.
+ */
+function cgpayGrantsParseFlds($body, $required) {
+  $out = [];
+
+  if (array_key_exists('amount', $body) || $required) {
+    $amount = nni($body, 'amount');
+    if ($required || $amount !== null) {
+      if ($err = u\badAmount($amount, '>0')) return $err;
+      $out['amount'] = $amount;
+    }
+  }
+
+  if (array_key_exists('by', $body) || $required) {
+    $by = strtolower(trim((string) nni($body, 'by')));
+    if ($required || $by !== '') {
+      if (!in_array($by, ['ach', 'check', 'wire'], TRUE)) return 'bad payment method';
+      $out['by'] = $by;
+    }
+  }
+
+  if (array_key_exists('fund', $body)) {
+    $out['fund'] = trim((string) nni($body, 'fund')) ?: null;
+  }
+
+  return $out;
+}
+
+function cgpayGrantsHasGrantorInput($body) {
+  foreach (['fullName', 'email', 'phone', 'address', 'city', 'state', 'zip', 'grantorPid'] as $k) {
+    if (array_key_exists($k, $body)) return TRUE;
+  }
+  return FALSE;
+}
+
+/**
+ * Resolve the grantor's people-table pid, applying William's edit rules.
+ * @param array $body        Full request body (already validated as array).
+ * @param int   $sponseeUid  Sponsee account uid (changedBy for changes-table entries).
+ * @param int|null $fallbackPid  When updating, the existing grants row's pid (used if body omits grantorPid).
+ * @return int|string  The resolved pid, or an error message string.
+ */
+function cgpayGrantsResolveGrantorPid($body, $sponseeUid, $fallbackPid = null) {
+  $fullName = trim((string) nni($body, 'fullName'));
+  if ($fullName === '') return 'grantor name required';
+  if ($err = u\badName($fullName)) return $err;
+
+  $grantorPid = (int) nni($body, 'grantorPid') ?: $fallbackPid;
+
+  $contact = cgpayGrantsParseContactFlds($body);
+  if (is_string($contact)) return $contact;
+
+  if ($grantorPid) {
+    $existing = db\row('people', ['pid' => $grantorPid]);
+    if (!$existing) $grantorPid = null;
+  }
+
+  if (!$grantorPid || strcasecmp(trim((string) $existing->fullName), $fullName) !== 0) {
+    // No prior grantor, or the name changed — treat as a new entity.
+    return db\insert('people', ['fullName' => $fullName] + $contact, 'pid');
+  }
+
+  // Same grantor — apply smart field-update rules.
+  $updates = [];
+  $changes = [];
+  foreach ($contact as $field => $newVal) {
+    if ($newVal === '' || $newVal === null) continue;
+    $oldVal = (string) ($existing->$field ?? '');
+    if ((string) $newVal === $oldVal) continue;
+    $updates[$field] = $newVal;
+    if ($oldVal !== '') $changes[$field] = ['old' => $oldVal, 'new' => (string) $newVal];
+  }
+
+  if ($updates) {
+    db\update('people', ['pid' => $grantorPid] + $updates, 'pid');
+    foreach ($changes as $field => $vals) {
+      db\insert('changes', [
+        'table'     => 'people',
+        'rid'       => $grantorPid,
+        'field'     => $field,
+        'oldValue'  => $vals['old'],
+        'newValue'  => $vals['new'],
+        'changedBy' => $sponseeUid,
+      ]);
+    }
+    if ($changes) {
+      r\tellAdmin('grantor-contact-changed', ray(
+        'grantor sponsee fields',
+        $fullName, $sponseeUid, implode(', ', array_keys($changes))
+      ));
+    }
+  }
+
+  return $grantorPid;
+}
+
+/**
+ * Parse + validate optional grantor contact fields. Returns array of provided fields or an error string.
+ */
+function cgpayGrantsParseContactFlds($body) {
+  $email   = trim((string) nni($body, 'email'));
+  $phone   = trim((string) nni($body, 'phone'));
+  $address = trim((string) nni($body, 'address'));
+  $city    = trim((string) nni($body, 'city'));
+  $state   = nni($body, 'state') === null ? null : (int) nni($body, 'state');
+  $zip     = trim((string) nni($body, 'zip'));
+
+  if ($email !== '' && !u\validEmail($email))          return 'bad email';
+  if ($phone !== '' && ($err = u\badPhone($phone)))    return $err;
+  if ($zip   !== '' && ($err = u\badZip($zip)))        return $err;
+
+  return compact(ray('email phone address city state zip'));
 }
 
 function exitJsonError($msg) {

--- a/cgmembers/rcredits/forms/cgpaypeople.inc
+++ b/cgmembers/rcredits/forms/cgpaypeople.inc
@@ -1,0 +1,74 @@
+<?php
+namespace CG\Web;
+use CG as r;
+use CG\Db as db;
+
+/**
+ * @file
+ * People-table endpoints for the SvelteKit cgpay POC.
+ *
+ * Currently exposes:
+ *   GET /cgpay-people-autocomplete?uid=<sponsee_uid>&q=<query>&limit=<n>
+ *     → list of candidate grantors matching <query>, drawn from people who have
+ *       ever been a grantor OR who have been a prior donor to this sponsee.
+ *       Returns fields the caller can use to auto-populate the grants form.
+ *
+ * Requires the same X-CG-Internal-Token shared secret used by other /cgpay-*
+ * endpoints (CGPAY_SSO_SECRET, see defs.inc).
+ *
+ * Returns:
+ *   GET 200 {"people": [{pid, fullName, email, phone, address, city, state, zip}, ...]}
+ *   401 bad/missing shared secret
+ *   400 malformed input
+ *   404 uid does not resolve to a sponsee
+ */
+function cgpayPeopleAutocomplete() {
+  if (nni($_SERVER, 'REQUEST_METHOD') !== 'GET') return exitJust(X_SYNTAX);
+
+  $expected = CGPAY_SSO_SECRET;
+  $provided = nni($_SERVER, 'HTTP_X_CG_INTERNAL_TOKEN');
+  if (empty($expected) || empty($provided) || !hash_equals($expected, $provided)) {
+    return exitJust(X_UNAUTH);
+  }
+
+  $uid = (int) nni($_GET, 'uid');
+  if ($uid <= 0) return exitJust(X_SYNTAX);
+  $a = r\acct($uid);
+  if (!$a) return exitJust(X_NOTFOUND);
+  if (!$a->sponsored) return exitJust(X_FORBIDDEN);
+
+  $q = trim((string) nni($_GET, 'q'));
+  if (strlen($q) < 2) return exitJson(['people' => []], X_OK);
+
+  $limit = (int) nni($_GET, 'limit');
+  if ($limit <= 0 || $limit > 50) $limit = 20;
+
+  // Filter: anyone who has ever been a grantor (has a row in grants). This is a
+  // strict superset of "prior donor to this sponsee" — the ORDER BY promotes the
+  // sponsee-specific matches to the top of the list for relevance.
+  $like = '%' . $q . '%';
+  $sql = "SELECT p.pid, p.fullName, p.email, p.phone, p.address, p.city, p.state, p.zip
+          FROM people p
+          WHERE p.fullName LIKE :like
+          AND p.pid IN (SELECT DISTINCT pid FROM grants WHERE pid IS NOT NULL)
+          ORDER BY
+            CASE WHEN p.pid IN (SELECT DISTINCT pid FROM grants WHERE uid = :uid AND pid IS NOT NULL) THEN 0 ELSE 1 END,
+            p.fullName
+          LIMIT $limit";
+  $rows = db\q($sql, compact('like', 'uid'))->fetchAll(\PDO::FETCH_ASSOC);
+
+  $people = array_map(function($r) {
+    return [
+      'pid'      => (int) $r['pid'],
+      'fullName' => (string) $r['fullName'],
+      'email'    => (string) ($r['email']   ?? ''),
+      'phone'    => (string) ($r['phone']   ?? ''),
+      'address'  => (string) ($r['address'] ?? ''),
+      'city'     => (string) ($r['city']    ?? ''),
+      'state'    => $r['state'] !== null ? (int) $r['state'] : null,
+      'zip'      => (string) ($r['zip']     ?? ''),
+    ];
+  }, $rows);
+
+  return exitJson(['people' => $people], X_OK);
+}

--- a/cgmembers/rcredits/misc/_changes.log
+++ b/cgmembers/rcredits/misc/_changes.log
@@ -1,6 +1,5 @@
 2026-07-14 feat/grants-form-v2-api
-. added fund column to grants table (Fund within grant-making organization, per William):
-    ALTER TABLE grants ADD `fund` VARCHAR(255) NULL AFTER `pid`;
+. added fund column to grants table via Phinx migration db/migrations/20260722193000_grants_add_fund.php (Fund within grant-making organization, per William)
 . extended /cgpay-grants endpoint with PATCH support for editing existing grant records
 . added smart people-table resolution for grantor edits (create-new-on-name-change, silent-fill-missing, log-changes-and-alert-on-existing-field-update -- rules per William)
 . added /cgpay-people-autocomplete endpoint (people table lookup: prior grantors OR prior donors to this sponsee)

--- a/cgmembers/rcredits/misc/_changes.log
+++ b/cgmembers/rcredits/misc/_changes.log
@@ -1,3 +1,10 @@
+2026-07-14 feat/grants-form-v2-api
+. added fund column to grants table (Fund within grant-making organization, per William):
+    ALTER TABLE grants ADD `fund` VARCHAR(255) NULL AFTER `pid`;
+. extended /cgpay-grants endpoint with PATCH support for editing existing grant records
+. added smart people-table resolution for grantor edits (create-new-on-name-change, silent-fill-missing, log-changes-and-alert-on-existing-field-update -- rules per William)
+. added /cgpay-people-autocomplete endpoint (people table lookup: prior grantors OR prior donors to this sponsee)
+
 2022-11-01 feature/postmark2
 . fixed shortcomings in postmark feature
 

--- a/db/migrations/20260722193000_grants_add_fund.php
+++ b/db/migrations/20260722193000_grants_add_fund.php
@@ -1,0 +1,14 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+use Phinx\Db\Adapter\MysqlAdapter as phx;
+
+require_once __DIR__ . '/util.inc';
+
+class GrantsAddFund extends AbstractMigration {
+  public function change() {
+    $t = $this->table('grants');
+    $t->addColumn('fund', 'string', ray('length null comment after', 255, TRUE, 'specific Fund within grant-making organization (if any)', 'pid'));
+    $t->update();
+  }
+}


### PR DESCRIPTION
## Summary

First slice of the grants-form-v2 work. This PR ships the PHP API + schema layer. Admin-form UI (fsgrants.inc) and funder CRM export will follow in separate PRs.

**What's in:**
- `PATCH /cgpay-grants` - edit an existing expected-grant record (previously only GET list + POST create existed).
- `fund` column on the `grants` table - the "Specific Fund (if any) within that grant-making organization" ask per William. Surfaces in list responses; accepted on create + update.
- `cgpayGrantsResolveGrantorPid()` - implements the four grantor-edit rules William laid out:
  - No `grantorPid` or unknown pid -> new `people` row.
  - `grantorPid` provided, `fullName` changed -> new `people` row (treat as different entity).
  - `grantorPid` provided, `fullName` unchanged, missing field being filled -> silent update.
  - `grantorPid` provided, `fullName` unchanged, existing field changed -> update + log to `changes` table + `r\tellAdmin` alert.
- `GET /cgpay-people-autocomplete?uid=<sponsee>&q=<query>` - new endpoint. Filters people who have ever been a grantor (`pid IN (SELECT DISTINCT pid FROM grants)`). ORDER BY promotes prior donors to the current sponsee to the top of results. No new column on `people` needed - the grantor set is inferred from the grants table itself.
- `_changes.log` entry documenting the ALTER TABLE + changes for the deploy-time SQL run.
- New `'grantor-contact-changed'` string template for `r\tellAdmin`.

## Required SQL migration (per _changes.log SOP)

```sql
ALTER TABLE grants ADD `fund` VARCHAR(255) NULL AFTER `pid`;
```