### PR TITLE
feat(grants): fsgrants Fund field + grantor autocomplete + /cgpay-funders-export

### DIFF
--- a/cgmembers/rcredits/cg-menu.inc
+++ b/cgmembers/rcredits/cg-menu.inc
@@ -251,6 +251,7 @@ function menu($submenu = '') {
     'cgpay-lookup' => ['call', 'CGPay Lookup', '', ANY, 'cgpayLookup'], // server-to-server: SvelteKit cgpay POC identifier (qid/name/email/phone) -> uid resolution
     'cgpay-grants' => ['call', 'CGPay Grants', '', ANY, 'cgpayGrants'], // server-to-server: SvelteKit cgpay POC expected-grant list + create + update
     'cgpay-people-autocomplete' => ['call', 'CGPay People Autocomplete', '', ANY, 'cgpayPeopleAutocomplete'], // server-to-server: SvelteKit cgpay POC grantor autocomplete
+    'cgpay-funders-export' => ['call', 'CGPay Funders Export', '', ANY, 'cgpayFundersExport'], // server-to-server: SvelteKit cgpay POC funder CRM CSV export
     'cc' => ['call', 'Credit Card Donation', 'Pay 1', ANY],
     'donate-fbo' => ['call', t('Donate'), 'Pay 1', ANY], // deprecated (use donate instead), but still used by Kibilio as of 11/22/2021
   );

--- a/cgmembers/rcredits/forms/ajax.inc
+++ b/cgmembers/rcredits/forms/ajax.inc
@@ -67,6 +67,13 @@ function ajax($args = NULL) {
     case 'suggestWho': // get selections for a whoFld (see w\whoFldSubmit()
       $res = be\memberRay($myid, $aid, $data ? nni($data, 'restrict') : '');
       return exitJust(u\jsonize($res ? array_values($res) : []));
+
+    case 'suggestGrantor': // autocomplete over prior grantors for the Expected Grants form
+      $q = trim((string) nni($data, 'q'));
+      if (strlen($q) < 2) return exitJust(u\jsonize([]));
+      $sponseeUid = (int) (nni($data, 'sponseeUid') ?: $myid);
+      require_once R_ROOT . '/forms/cgpaypeople.inc';
+      return exitJust(u\jsonize(grantorAutocompleteRows($sponseeUid, $q, 20)));
     
     case 'suggestNonmember':
     /*  foreach (ray('fullName email phone, fullName address city state zip') as $flds) {

--- a/cgmembers/rcredits/forms/cgpaypeople.inc
+++ b/cgmembers/rcredits/forms/cgpaypeople.inc
@@ -7,29 +7,20 @@ use CG\Db as db;
  * @file
  * People-table endpoints for the SvelteKit cgpay POC.
  *
- * Currently exposes:
+ * Exposes:
  *   GET /cgpay-people-autocomplete?uid=<sponsee_uid>&q=<query>&limit=<n>
- *     → list of candidate grantors matching <query>, drawn from people who have
- *       ever been a grantor OR who have been a prior donor to this sponsee.
- *       Returns fields the caller can use to auto-populate the grants form.
+ *     → list of candidate grantors matching <query>. See grantorAutocompleteRows().
  *
- * Requires the same X-CG-Internal-Token shared secret used by other /cgpay-*
+ *   GET /cgpay-funders-export?format=<csv|mailerlite>
+ *     → downloadable CSV of all funders (everyone who has ever been a grantor).
+ *       `mailerlite` format uses the column headers MailerLite expects for imports.
+ *
+ * Both require the same X-CG-Internal-Token shared secret used by other /cgpay-*
  * endpoints (CGPAY_SSO_SECRET, see defs.inc).
- *
- * Returns:
- *   GET 200 {"people": [{pid, fullName, email, phone, address, city, state, zip}, ...]}
- *   401 bad/missing shared secret
- *   400 malformed input
- *   404 uid does not resolve to a sponsee
  */
 function cgpayPeopleAutocomplete() {
   if (nni($_SERVER, 'REQUEST_METHOD') !== 'GET') return exitJust(X_SYNTAX);
-
-  $expected = CGPAY_SSO_SECRET;
-  $provided = nni($_SERVER, 'HTTP_X_CG_INTERNAL_TOKEN');
-  if (empty($expected) || empty($provided) || !hash_equals($expected, $provided)) {
-    return exitJust(X_UNAUTH);
-  }
+  if (!cgpaySharedSecretOk()) return exitJust(X_UNAUTH);
 
   $uid = (int) nni($_GET, 'uid');
   if ($uid <= 0) return exitJust(X_SYNTAX);
@@ -43,10 +34,50 @@ function cgpayPeopleAutocomplete() {
   $limit = (int) nni($_GET, 'limit');
   if ($limit <= 0 || $limit > 50) $limit = 20;
 
-  // Filter: anyone who has ever been a grantor (has a row in grants). This is a
-  // strict superset of "prior donor to this sponsee" — the ORDER BY promotes the
-  // sponsee-specific matches to the top of the list for relevance.
+  $people = grantorAutocompleteRows($uid, $q, $limit);
+  return exitJson(['people' => $people], X_OK);
+}
+
+function cgpayFundersExport() {
+  if (nni($_SERVER, 'REQUEST_METHOD') !== 'GET') return exitJust(X_SYNTAX);
+  if (!cgpaySharedSecretOk()) return exitJust(X_UNAUTH);
+
+  $format = strtolower(trim((string) nni($_GET, 'format'))) ?: 'csv';
+  if (!in_array($format, ['csv', 'mailerlite'], TRUE)) return exitJust(X_SYNTAX);
+
+  $rows = fundersExportRows();
+  fundersEmitCsv($rows, $format);
+  exit;
+}
+
+/**
+ * Verify the shared-secret header used by all /cgpay-* server-to-server endpoints.
+ */
+function cgpaySharedSecretOk() {
+  $expected = CGPAY_SSO_SECRET;
+  $provided = nni($_SERVER, 'HTTP_X_CG_INTERNAL_TOKEN');
+  return !empty($expected) && !empty($provided) && hash_equals($expected, $provided);
+}
+
+/**
+ * Autocomplete-shaped rows: matching people who have ever been a grantor,
+ * with prior donors to $sponseeUid promoted to the top.
+ * Shared by /cgpay-people-autocomplete (server-to-server) and the admin ajax
+ * `suggestGrantor` op in forms/ajax.inc.
+ *
+ * @param int    $sponseeUid  Used only for ORDER BY (prior-donor-to-this-sponsee ranks first).
+ * @param string $q           Query string, >= 2 chars (caller enforces).
+ * @param int    $limit       Max rows to return (caller-bounded).
+ * @return array              List of [pid, fullName, email, phone, address, city, state, zip].
+ */
+function grantorAutocompleteRows($sponseeUid, $q, $limit = 20) {
+  $sponseeUid = (int) $sponseeUid;
+  $limit = max(1, min(50, (int) $limit));
   $like = '%' . $q . '%';
+
+  // Filter: anyone who has ever been a grantor (has a row in grants). Strict
+  // superset of "prior donor to this sponsee" — ORDER BY promotes matches for
+  // the current sponsee first.
   $sql = "SELECT p.pid, p.fullName, p.email, p.phone, p.address, p.city, p.state, p.zip
           FROM people p
           WHERE p.fullName LIKE :like
@@ -55,9 +86,9 @@ function cgpayPeopleAutocomplete() {
             CASE WHEN p.pid IN (SELECT DISTINCT pid FROM grants WHERE uid = :uid AND pid IS NOT NULL) THEN 0 ELSE 1 END,
             p.fullName
           LIMIT $limit";
-  $rows = db\q($sql, compact('like', 'uid'))->fetchAll(\PDO::FETCH_ASSOC);
+  $rows = db\q($sql, ['like' => $like, 'uid' => $sponseeUid])->fetchAll(\PDO::FETCH_ASSOC);
 
-  $people = array_map(function($r) {
+  return array_map(function($r) {
     return [
       'pid'      => (int) $r['pid'],
       'fullName' => (string) $r['fullName'],
@@ -69,6 +100,69 @@ function cgpayPeopleAutocomplete() {
       'zip'      => (string) ($r['zip']     ?? ''),
     ];
   }, $rows);
+}
 
-  return exitJson(['people' => $people], X_OK);
+/**
+ * All funders (everyone who's ever been a grantor), with aggregate stats:
+ *   pid, fullName, email, phone, address, city, state, zip, grantCount, totalGranted, lastGrantAt
+ */
+function fundersExportRows() {
+  $sql = "SELECT p.pid, p.fullName, p.email, p.phone, p.address, p.city, p.state, p.zip,
+                 COUNT(g.id) AS grantCount, SUM(g.amount) AS totalGranted, MAX(g.created) AS lastGrantAt
+          FROM people p
+          JOIN grants g USING (pid)
+          WHERE g.pid IS NOT NULL
+          GROUP BY p.pid
+          ORDER BY p.fullName";
+  return db\q($sql)->fetchAll(\PDO::FETCH_ASSOC);
+}
+
+/**
+ * Stream funder rows as CSV to the browser and exit.
+ * @param array  $rows    Rows from fundersExportRows().
+ * @param string $format  'csv' (raw columns) or 'mailerlite' (MailerLite-import headers).
+ */
+function fundersEmitCsv($rows, $format) {
+  $stamp = date('Y-m-d');
+  $filename = "funders-{$format}-{$stamp}.csv";
+  header('Content-Type: text/csv; charset=utf-8');
+  header('Content-Disposition: attachment; filename="' . $filename . '"');
+
+  $out = fopen('php://output', 'w');
+  if ($format === 'mailerlite') {
+    // MailerLite import headers — email is the only required column.
+    fputcsv($out, ['email', 'name', 'phone', 'city', 'state', 'zip', 'grant_count', 'total_granted', 'last_grant_at']);
+    foreach ($rows as $r) {
+      if (empty($r['email'])) continue; // MailerLite requires email
+      fputcsv($out, [
+        $r['email'],
+        $r['fullName'],
+        $r['phone'],
+        $r['city'],
+        $r['state'],
+        $r['zip'],
+        (int) $r['grantCount'],
+        (float) $r['totalGranted'],
+        $r['lastGrantAt'] ? date('Y-m-d', (int) $r['lastGrantAt']) : '',
+      ]);
+    }
+  } else {
+    fputcsv($out, ['pid', 'fullName', 'email', 'phone', 'address', 'city', 'state', 'zip', 'grantCount', 'totalGranted', 'lastGrantAt']);
+    foreach ($rows as $r) {
+      fputcsv($out, [
+        (int) $r['pid'],
+        $r['fullName'],
+        $r['email'],
+        $r['phone'],
+        $r['address'],
+        $r['city'],
+        $r['state'],
+        $r['zip'],
+        (int) $r['grantCount'],
+        (float) $r['totalGranted'],
+        $r['lastGrantAt'] ? date('Y-m-d', (int) $r['lastGrantAt']) : '',
+      ]);
+    }
+  }
+  fclose($out);
 }

--- a/cgmembers/rcredits/forms/fsgrants.inc
+++ b/cgmembers/rcredits/forms/fsgrants.inc
@@ -6,7 +6,7 @@ use CG\Backend as be;
 use CG\Util as u;
 use CG\Db as db;
 
-const FSGRANTS_FLDS = 'id uid pid xid amount by ckNum ckDate documented received created'; // just the fields we handle here (and omitting pid)
+const FSGRANTS_FLDS = 'id uid pid xid amount by fund ckNum ckDate documented received created'; // just the fields we handle here (and omitting pid)
 require_once R_ROOT . '/forms/tx.inc'; // for txErr()
 require_once R_ROOT . '/forms/people.inc'; // for PEOPLE_FLDS
 
@@ -40,6 +40,8 @@ function formFSGrants($form, &$sta, $args = '') {
   $zip = zipFld($zip);
   $methods = ray(METHOD_OPTS);
 
+  $fund = textFld(t('Fund:'), [t('Specific Fund (if any) within that grant-making organization')], dft($fund));
+
   $amount = numFld(REQ . t('Expected Amount:'), [t('Amount')], dft($amount) + vmin(.01));
 
   $opts = ray(tr(PAYBY_OPTS));
@@ -62,10 +64,10 @@ function formFSGrants($form, &$sta, $args = '') {
   foreach (ray('url seeAll') as $k) $$k = hidFld($$k);
   $sta['no_cache'] = TRUE; // otherwise the javascript-populated dropdowns get lost
 
-  $form = compact(ray('title subtext fullName email phone address city state zip amount by ckNum ckDate documented got received submit orig url seeAll'));
-        
+  $form = compact(ray('title subtext fullName email phone address city state zip amount by fund ckNum ckDate documented got received submit orig url seeAll'));
+
   jsx('contact');
-  jsx('fsgrants', ray('byCheck undocMax', B_CHECK, UNDOC_GRANT_MAX));
+  jsx('fsgrants', ray('byCheck undocMax sponseeUid', B_CHECK, UNDOC_GRANT_MAX, $myid));
 
   return cgform($form);
 }

--- a/cgmembers/rcredits/js/misc.js
+++ b/cgmembers/rcredits/js/misc.js
@@ -265,7 +265,40 @@ function suggestWho(sel, restrict) {
   );
 
 }
-    
+
+/**
+ * Typeahead over prior grantors for the Expected Grants form.
+ * On select, fills the sibling contact fields (email, phone, address, city, state, zip).
+ * @param string sel: selector for the grantor-name input
+ * @param int    sponseeUid: current sponsee uid (used to rank prior donors first)
+ */
+function suggestGrantor(sel, sponseeUid) {
+  var grantors = new Bloodhound({
+    identify: function(o) { return o.pid; },
+    datumTokenizer: Bloodhound.tokenizers.obj.whitespace('fullName'),
+    queryTokenizer: Bloodhound.tokenizers.whitespace,
+    remote: {
+      url: ajaxUrl + '?op=suggestGrantor&data=' + encodeURIComponent(JSON.stringify({sponseeUid: sponseeUid, q: '%QUERY'})).replace('%25QUERY', '%QUERY') + '&sid=' + ajaxSid,
+      wildcard: '%QUERY'
+    }
+  });
+
+  $(sel).on('typeahead:select typeahead:autocomplete', function(ev, o) {
+    var form = $(sel).closest('form');
+    if (o.email)   $('input[name=email]',   form).val(o.email);
+    if (o.phone)   $('input[name=phone]',   form).val(o.phone);
+    if (o.address) $('input[name=address]', form).val(o.address);
+    if (o.city)    $('input[name=city]',    form).val(o.city);
+    if (o.state && o.state > 0) $('select[name=state]', form).val(o.state);
+    if (o.zip)     $('input[name=zip]',     form).val(o.zip);
+  });
+
+  $(sel).wrap('<div></div>').typeahead(
+    { minLength: 2, highlight: true },
+    { name: 'grantors', source: grantors, display: 'fullName' }
+  );
+}
+
 var signoutWarning = 'You still there? (otherwise we\'ll sign you out, to protect your account)';
 
 function sessionTimeout() {

--- a/cgmembers/rcredits/js/scraps.js
+++ b/cgmembers/rcredits/js/scraps.js
@@ -298,6 +298,7 @@ function doit(what, vs) {
       if (toggleCkFlds(vs)) $('.form-item-ckNum input').focus();
     });
     $('.form-item-amount input').change(function () {$('.form-item-documented').toggle(this.value >= vs['undocMax'])});
+    suggestGrantor('#edit-fullname', vs['sponseeUid']);
     break;
     
   case 'tx':

--- a/cgmembers/rcredits/misc/_changes.log
+++ b/cgmembers/rcredits/misc/_changes.log
@@ -1,3 +1,9 @@
+2026-07-14 feat/grants-form-v2-ui
+. added Fund field to the Expected Grants admin form (fsgrants.inc)
+. added grantor autocomplete on the Grantor Name field: typeahead over prior grantors, selecting one auto-fills the contact fields
+. added ajax `suggestGrantor` op (forms/ajax.inc) that calls the shared grantorAutocompleteRows() helper
+. added /cgpay-funders-export endpoint (CSV or MailerLite-shaped export of all funders, with grant count / total / last-grant-at aggregates)
+
 2026-07-14 feat/grants-form-v2-api
 . added fund column to grants table (Fund within grant-making organization, per William):
     ALTER TABLE grants ADD `fund` VARCHAR(255) NULL AFTER `pid`;


### PR DESCRIPTION
## Summary

Second slice of grants form v2. **Stacked on top of #43** - targets `feat/grants-form-v2-api` as the base so the two PRs review cleanly. Once #43 merges to develop, re-target this PR to develop and rebase.

**What's in:**

**Admin form (fsgrants.inc):**
- New **Fund** text field with helper text ("Specific Fund (if any) within that grant-making organization").
- Grantor Name field now has a typeahead autocomplete over prior grantors. Selecting a match auto-fills the sibling contact fields (email / phone / address / city / state / zip). Prior donors to the current sponsee are ranked first.
- Existing `fboTx` submit path handles the rest - no smart grantor rules on the admin path (admin IS the editor; log-and-alert only makes sense for the sponsee-facing API path in #43).

**Shared autocomplete plumbing:**
- Extracted `grantorAutocompleteRows()` helper in `cgpaypeople.inc` so the shared-secret endpoint and the admin ajax handler use one implementation.
- New `suggestGrantor` op in `forms/ajax.inc` (session-authed, admin-facing).
- New `suggestGrantor()` JS in `misc.js` (Bloodhound + Typeahead.js, matching the existing `suggestWho()` pattern).

**Funder CRM export (Jose's ask):**
- New `GET /cgpay-funders-export?format=<csv|mailerlite>` endpoint.
- Returns a downloadable CSV of everyone who's ever been a grantor, with `grantCount`, `totalGranted`, and `lastGrantAt` aggregates.
- `mailerlite` format skips no-email rows and uses the column headers MailerLite expects for imports.