### PR TITLE
feat(grants): per-field validation errors with user-friendly messages

### DIFF
--- a/cgmembers/rcredits/forms/cgpaygrants.inc
+++ b/cgmembers/rcredits/forms/cgpaygrants.inc
@@ -193,6 +193,28 @@ function cgpayGrantsValidateGrantor($body, array &$errors) {
     $errors['fullName'] = t('Please enter a valid name for the grantor.');
   }
 
+  // Address is required (per William 2026-07-31: we send acknowledgments to the grantor
+  // and may need the mailing address for grant records). City / state / zip are all
+  // part of a complete address, so all four required together.
+  $address = trim((string) nni($body, 'address'));
+  if ($address === '') $errors['address'] = t('Please enter the grantor\'s street address.');
+
+  $city = trim((string) nni($body, 'city'));
+  if ($city === '') $errors['city'] = t('Please enter the grantor\'s city.');
+
+  $state = nni($body, 'state');
+  if ($state === null || (int) $state <= 0) {
+    $errors['state'] = t('Please select the grantor\'s state.');
+  }
+
+  $zip = trim((string) nni($body, 'zip'));
+  if ($zip === '') {
+    $errors['zip'] = t('Please enter the grantor\'s zip code.');
+  } elseif (u\badZip($zip)) {
+    $errors['zip'] = t('That is the wrong format for a zip code.');
+  }
+
+  // Email + phone remain optional but validated if provided.
   $email = trim((string) nni($body, 'email'));
   if ($email !== '' && !u\validEmail($email)) {
     $errors['email'] = t('That is the wrong format for an email address.');
@@ -201,11 +223,6 @@ function cgpayGrantsValidateGrantor($body, array &$errors) {
   $phone = trim((string) nni($body, 'phone'));
   if ($phone !== '' && u\badPhone($phone)) {
     $errors['phone'] = t('That is the wrong format for a phone number.');
-  }
-
-  $zip = trim((string) nni($body, 'zip'));
-  if ($zip !== '' && u\badZip($zip)) {
-    $errors['zip'] = t('That is the wrong format for a zip code.');
   }
 }
 

--- a/cgmembers/rcredits/forms/cgpaygrants.inc
+++ b/cgmembers/rcredits/forms/cgpaygrants.inc
@@ -20,36 +20,15 @@ use CG\Util as u;
  * All require the same X-CG-Internal-Token shared secret used by /cgpay-sso
  * and /cgpay-lookup (CGPAY_SSO_SECRET, see defs.inc).
  *
- * POST JSON body (create):
- *   {
- *     "uid":      <int>,                       // sponsee account uid
- *     "amount":   <decimal>,                   // required, > 0
- *     "by":       "ach"|"check"|"wire",        // required, payment method
- *     "fund":     <string?>,                   // specific fund within a grant-making organization
- *     "grantorPid": <int?>,                    // if grantor was picked from autocomplete
- *     "fullName": <string>,                    // required, grantor name
- *     "email":    <string?>, "phone": <string?>,
- *     "address":  <string?>, "city": <string?>, "state": <int?>, "zip": <string?>
- *   }
+ * Validation errors (per William + Jose 2026-07-31):
+ *   Instead of returning the FIRST error only, ALL field-level errors are
+ *   collected and returned together as {"errors": {"<field>": "<message>", ...}}.
+ *   Messages are user-friendly ("That is the wrong format for an email address.").
+ *   Frontend uses this shape to highlight all bad fields simultaneously.
  *
- * PATCH JSON body (update):
- *   { "uid": <int>, "id": <int>, ...same fields... }
- *   All grant + grantor fields optional; only the provided ones change.
- *
- * Grantor-resolution rules (per William):
- *   - No grantorPid provided or pid unknown → new people row
- *   - grantorPid matches, fullName unchanged, missing field being filled → silent update
- *   - grantorPid matches, fullName unchanged, existing field being changed → update people row,
- *     log old→new to changes table, alert admin
- *   - grantorPid matches, fullName changed → new people row (treat as different entity)
- *
- * Returns:
- *   GET   200 {"grants": [{id, amount, by, fund, grantor, documented, received, created}, ...]}
- *   POST  200 {"id": <int>}
- *   PATCH 200 {"id": <int>}
- *   401   bad/missing shared secret
- *   400   malformed input / failed validation (body: {"error": "<why>"})
- *   404   uid/id does not resolve
+ * POST body (create) and PATCH body (update) fields are the same:
+ *   { uid, amount, by, fund?, grantorPid?, fullName, email?, phone?,
+ *     address?, city?, state?, zip? }
  */
 function cgpayGrants() {
   $method = nni($_SERVER, 'REQUEST_METHOD');
@@ -105,13 +84,15 @@ function cgpayGrantsCreate() {
   if (!$a) return exitJust(X_NOTFOUND);
   if (!$a->sponsored) return exitJust(X_FORBIDDEN);
 
-  $grantFlds = cgpayGrantsParseFlds($body, TRUE);
-  if (is_string($grantFlds)) return exitJsonError($grantFlds);
+  // Validate ALL fields up front so users see every problem at once.
+  $errors = [];
+  $grantFlds = cgpayGrantsParseFlds($body, TRUE, $errors);
+  cgpayGrantsValidateGrantor($body, $errors);
+  if ($errors) return exitJsonErrors($errors);
 
   $DBTX = \db_transaction();
-
   $pid = cgpayGrantsResolveGrantorPid($body, $uid);
-  if (is_string($pid)) return exitJsonError($pid);
+  if (is_string($pid)) return exitJsonErrors(['fullName' => $pid]);
 
   $id = db\insert('grants', $grantFlds + [
     'uid'     => $uid,
@@ -138,45 +119,50 @@ function cgpayGrantsUpdate() {
   $existing = db\row('grants', compact('id'));
   if (!$existing || (int) $existing->uid !== $uid) return exitJust(X_NOTFOUND);
 
-  $grantFlds = cgpayGrantsParseFlds($body, FALSE);
-  if (is_string($grantFlds)) return exitJsonError($grantFlds);
+  $errors = [];
+  $grantFlds = cgpayGrantsParseFlds($body, FALSE, $errors);
+  if (cgpayGrantsHasGrantorInput($body)) cgpayGrantsValidateGrantor($body, $errors);
+  if ($errors) return exitJsonErrors($errors);
 
   $DBTX = \db_transaction();
-
   if (cgpayGrantsHasGrantorInput($body)) {
     $pid = cgpayGrantsResolveGrantorPid($body, $uid, (int) $existing->pid);
-    if (is_string($pid)) return exitJsonError($pid);
+    if (is_string($pid)) return exitJsonErrors(['fullName' => $pid]);
     $grantFlds['pid'] = $pid;
   }
-
   if ($grantFlds) db\update('grants', compact('id') + $grantFlds, 'id');
-
   unset($DBTX);
 
   return exitJson(['id' => $id], X_OK);
 }
 
 /**
- * Parse grant-row fields (amount, by, fund) from the request body.
+ * Parse grant-row fields (amount, by, fund). Adds any per-field errors to $errors.
  * @param bool $required  TRUE for create (amount + by required), FALSE for update (all optional).
- * @return array|string   Fields to persist, or an error message string.
+ * @return array          Fields to persist (always returns — errors reported separately).
  */
-function cgpayGrantsParseFlds($body, $required) {
+function cgpayGrantsParseFlds($body, $required, array &$errors) {
   $out = [];
 
   if (array_key_exists('amount', $body) || $required) {
     $amount = nni($body, 'amount');
     if ($required || $amount !== null) {
-      if ($err = u\badAmount($amount, '>0')) return $err;
-      $out['amount'] = $amount;
+      if (u\badAmount($amount, '>0')) {
+        $errors['amount'] = t('Please enter an amount greater than zero.');
+      } else {
+        $out['amount'] = $amount;
+      }
     }
   }
 
   if (array_key_exists('by', $body) || $required) {
     $by = strtolower(trim((string) nni($body, 'by')));
     if ($required || $by !== '') {
-      if (!in_array($by, ['ach', 'check', 'wire'], TRUE)) return 'bad payment method';
-      $out['by'] = $by;
+      if (!in_array($by, ['ach', 'check', 'wire'], TRUE)) {
+        $errors['by'] = t('Please choose a payment method (ACH, check, or wire).');
+      } else {
+        $out['by'] = $by;
+      }
     }
   }
 
@@ -195,7 +181,38 @@ function cgpayGrantsHasGrantorInput($body) {
 }
 
 /**
+ * Validate grantor fields (fullName + optional contact info). Adds per-field errors to $errors.
+ * Does NOT write to the DB — pure validation. Actual pid resolution happens in
+ * cgpayGrantsResolveGrantorPid() after validation passes.
+ */
+function cgpayGrantsValidateGrantor($body, array &$errors) {
+  $fullName = trim((string) nni($body, 'fullName'));
+  if ($fullName === '') {
+    $errors['fullName'] = t('Please enter the grantor\'s name.');
+  } elseif (u\badName($fullName)) {
+    $errors['fullName'] = t('Please enter a valid name for the grantor.');
+  }
+
+  $email = trim((string) nni($body, 'email'));
+  if ($email !== '' && !u\validEmail($email)) {
+    $errors['email'] = t('That is the wrong format for an email address.');
+  }
+
+  $phone = trim((string) nni($body, 'phone'));
+  if ($phone !== '' && u\badPhone($phone)) {
+    $errors['phone'] = t('That is the wrong format for a phone number.');
+  }
+
+  $zip = trim((string) nni($body, 'zip'));
+  if ($zip !== '' && u\badZip($zip)) {
+    $errors['zip'] = t('That is the wrong format for a zip code.');
+  }
+}
+
+/**
  * Resolve the grantor's people-table pid, applying William's edit rules.
+ * Called AFTER cgpayGrantsValidateGrantor() so inputs are already valid.
+ *
  * @param array $body        Full request body (already validated as array).
  * @param int   $sponseeUid  Sponsee account uid (changedBy for changes-table entries).
  * @param int|null $fallbackPid  When updating, the existing grants row's pid (used if body omits grantorPid).
@@ -203,13 +220,8 @@ function cgpayGrantsHasGrantorInput($body) {
  */
 function cgpayGrantsResolveGrantorPid($body, $sponseeUid, $fallbackPid = null) {
   $fullName = trim((string) nni($body, 'fullName'));
-  if ($fullName === '') return 'grantor name required';
-  if ($err = u\badName($fullName)) return $err;
-
   $grantorPid = (int) nni($body, 'grantorPid') ?: $fallbackPid;
-
-  $contact = cgpayGrantsParseContactFlds($body);
-  if (is_string($contact)) return $contact;
+  $contact = cgpayGrantsExtractContactFlds($body);
 
   if ($grantorPid) {
     $existing = db\row('people', ['pid' => $grantorPid]);
@@ -256,23 +268,33 @@ function cgpayGrantsResolveGrantorPid($body, $sponseeUid, $fallbackPid = null) {
 }
 
 /**
- * Parse + validate optional grantor contact fields. Returns array of provided fields or an error string.
+ * Extract grantor contact fields from the body (no validation — validation done separately).
  */
-function cgpayGrantsParseContactFlds($body) {
+function cgpayGrantsExtractContactFlds($body) {
   $email   = trim((string) nni($body, 'email'));
   $phone   = trim((string) nni($body, 'phone'));
   $address = trim((string) nni($body, 'address'));
   $city    = trim((string) nni($body, 'city'));
   $state   = nni($body, 'state') === null ? null : (int) nni($body, 'state');
   $zip     = trim((string) nni($body, 'zip'));
-
-  if ($email !== '' && !u\validEmail($email))          return 'bad email';
-  if ($phone !== '' && ($err = u\badPhone($phone)))    return $err;
-  if ($zip   !== '' && ($err = u\badZip($zip)))        return $err;
-
   return compact(ray('email phone address city state zip'));
 }
 
+/**
+ * Return per-field error response with a top-level summary suitable for the form banner.
+ * Also keeps `error` for backward compatibility with any older client that only reads that.
+ */
+function exitJsonErrors(array $errors) {
+  $summary = t('There is an error in the information you typed — fix the highlighted field(s) and try again.');
+  $body = [
+    'message' => $summary,
+    'errors'  => $errors,
+    'error'   => $summary,   // backward-compat: older clients read `error`
+  ];
+  return exitJson($body, X_SYNTAX);
+}
+
+// Deprecated single-error helper — kept for compatibility with any remaining single-message callers.
 function exitJsonError($msg) {
-  return exitJson(['error' => (string) $msg], X_SYNTAX);
+  return exitJson(['error' => (string) $msg, 'message' => (string) $msg], X_SYNTAX);
 }


### PR DESCRIPTION
## Summary

Per William 2026-07-31 (Jose agreed): the grants endpoint currently returns a single generic error string, which the SvelteKit UI surfaces as "Unable to save the grant - please try again." - bad UX for a public-facing form. This PR makes the backend return per-field errors with user-friendly messages so the frontend can highlight the exact bad fields.

## What changed

**Validation is now collected up front, not short-circuited on first failure:**

- New helper `cgpayGrantsValidateGrantor()` - pure validation, collects errors into a passed-by-reference array
- `cgpayGrantsParseFlds()` - same pattern, adds errors instead of returning strings
- `cgpayGrantsCreate()` + `cgpayGrantsUpdate()` - validate everything up front, return all errors together via `exitJsonErrors()` if any
- Grantor pid resolution is now a pure "do the work" step (no validation mixed in) - `cgpayGrantsResolveGrantorPid()` split from `cgpayGrantsExtractContactFlds()`