### PR TITLE
change inquiry about few transactions to 90 days and just once per gap

### DIFF
--- a/cgmembers/rcredits/cg-strings.inc
+++ b/cgmembers/rcredits/cg-strings.inc
@@ -303,7 +303,7 @@ EOF
   'confirm funding' => t('%confirmAction %amount to %otherName?'),
   'please confirm' => t('To confirm, type: %nonce'),
   'verification code' => t('Your verification code for using %PROJECT online is: %nonce'), // used in rWeb
-  'whats up' => t('<p>You have not had any %PROJECT transactions in the past month. Most members have at least one transaction per month, so this is a little unusual and we hope all is well with you.</p><p>No need to reply. But please email or call us if you have any problems or questions.</p>'),
+  'whats up' => t('<p>You have not had any %PROJECT transactions in the past 90 days. Most members have at least one transaction per quarter, so this is a little unusual and we hope all is well with you.</p><p>No need to reply. But please email or call us if you have any problems or questions.</p>'),
   'co promo' => t('And if you need more promotional cards to hand out to customers, just let us know!'),
   'thank tell' => t('Thank you for telling us!'),
   'acct deleted' => t('Your account has been deleted.'),

--- a/cgmembers/rcredits/rcron/rcron.inc
+++ b/cgmembers/rcredits/rcron/rcron.inc
@@ -759,12 +759,13 @@ function everyWeek() {
  */
 function everyMonth() {
   $start = u\monthDay1($end = u\monthDay1() - 1); // mark start and end of preceding month
+  $qtrAgo = strtotime('today -90 days');
   if (test()) $start = strtotime('-30 days', $end = today() - 1) + 1; // test: the past 30 days
 
-  $omitUids = r\qo('NEWARJ')->id // people who don't want to see the "whats up" message
-  . ',' . r\qo('NEWBWN')->id;
+  foreach (ray('NEWARJ NEWBWN NEWCGO') as $qid) $omitUids[] = r\qo($qid)->id; // people who don't want to see the "whats up" message
+  $omitUids = join(',', $omitUids);
   
-  queueEach('whatsup', "SELECT DISTINCT uid, u.:IS_CO as co, MAX(t.created) AS lastTx FROM users u LEFT JOIN tx_entries e USING(uid) JOIN tx_hdrs t USING(xid) WHERE uid>:UID_CANON9 AND uid NOT IN ($omitUids) AND u.:IS_OK GROUP BY uid HAVING lastTx IS NULL OR lastTx < $start");
+  queueEach('whatsup', "SELECT DISTINCT uid, u.:IS_CO as co, MAX(t.created) AS lastTx, activated FROM users u LEFT JOIN tx_entries e USING(uid) JOIN tx_hdrs t USING(xid) WHERE uid>:UID_CANON9 AND uid NOT IN ($omitUids) AND u.:IS_OK GROUP BY uid HAVING UNIX_TIMESTAMP(DATE(FROM_UNIXTIME(IFNULL(lastTx, activated)))) = $qtrAgo"); // do this just once per gap: inquire if no tx in 90 days
   
   $sql = <<< X
     SELECT DISTINCT u.uid, ROUND(SUM(t.amt)*u.crumbs, 2) AS donate, $end AS date

--- a/cgmembers/rcredits/rcron/rcron.inc
+++ b/cgmembers/rcredits/rcron/rcron.inc
@@ -234,6 +234,13 @@ X;
     unset($DBTX);
   }
   db\q('DELETE FROM x_txs2 WHERE amount=0'); // no need to track these
+  
+  // Nudge accounts that haven't had a transaction recently
+  $qtrAgo = strtotime('today -90 days');
+  foreach (ray('NEWARJ NEWBWN NEWCGO') as $qid) $omitUids[] = r\qo($qid)->id; // people who don't want to see the "whats up" message
+  $omitUids = join(',', $omitUids);
+  
+  queueEach('whatsup', "SELECT DISTINCT uid, u.:IS_CO as co, MAX(t.created) AS lastTx, activated FROM users u LEFT JOIN tx_entries e USING(uid) JOIN tx_hdrs t USING(xid) WHERE uid>:UID_CANON9 AND uid NOT IN ($omitUids) AND u.:IS_OK GROUP BY uid HAVING UNIX_TIMESTAMP(DATE(FROM_UNIXTIME(IFNULL(lastTx, activated)))) = $qtrAgo"); // do this just once per gap: inquire if no tx in 90 days
 }
 
 /**
@@ -759,14 +766,8 @@ function everyWeek() {
  */
 function everyMonth() {
   $start = u\monthDay1($end = u\monthDay1() - 1); // mark start and end of preceding month
-  $qtrAgo = strtotime('today -90 days');
   if (test()) $start = strtotime('-30 days', $end = today() - 1) + 1; // test: the past 30 days
 
-  foreach (ray('NEWARJ NEWBWN NEWCGO') as $qid) $omitUids[] = r\qo($qid)->id; // people who don't want to see the "whats up" message
-  $omitUids = join(',', $omitUids);
-  
-  queueEach('whatsup', "SELECT DISTINCT uid, u.:IS_CO as co, MAX(t.created) AS lastTx, activated FROM users u LEFT JOIN tx_entries e USING(uid) JOIN tx_hdrs t USING(xid) WHERE uid>:UID_CANON9 AND uid NOT IN ($omitUids) AND u.:IS_OK GROUP BY uid HAVING UNIX_TIMESTAMP(DATE(FROM_UNIXTIME(IFNULL(lastTx, activated)))) = $qtrAgo"); // do this just once per gap: inquire if no tx in 90 days
-  
   $sql = <<< X
     SELECT DISTINCT u.uid, ROUND(SUM(t.amt)*u.crumbs, 2) AS donate, $end AS date
     FROM users u LEFT JOIN txs_noreverse t ON t.uid2=u.uid


### PR DESCRIPTION
Members get annoyed by being asked monthly if everything is alright every time they go 30 days without a transaction. This fix changes it to 90 days and asks only once per gap (exactly 90 days since their last transaction).