### PR TITLE
feat(grants): ckNum + ckDate on /cgpay-grants when payment = check

### DIFF
--- a/cgmembers/rcredits/forms/cgpaygrants.inc
+++ b/cgmembers/rcredits/forms/cgpaygrants.inc
@@ -170,6 +170,31 @@ function cgpayGrantsParseFlds($body, $required, array &$errors) {
     $out['fund'] = trim((string) nni($body, 'fund')) ?: null;
   }
 
+  // Check-specific fields (per William 2026-08-04): when payment method is check,
+  // capture check number + check date up front so they land in the transaction
+  // description at release time. Required for check, ignored otherwise.
+  $isCheck = (nn($out, 'by') === 'check');
+  if ($isCheck || array_key_exists('ckNum', $body) || array_key_exists('ckDate', $body)) {
+    $ckNum = trim((string) nni($body, 'ckNum'));
+    if ($isCheck && $ckNum === '') {
+      $errors['ckNum'] = t('Please enter the check number.');
+    } elseif ($ckNum !== '') {
+      $out['ckNum'] = $ckNum;
+    }
+
+    $ckDateRaw = trim((string) nni($body, 'ckDate'));
+    if ($isCheck && $ckDateRaw === '') {
+      $errors['ckDate'] = t('Please enter the check date.');
+    } elseif ($ckDateRaw !== '') {
+      $ts = is_numeric($ckDateRaw) ? (int) $ckDateRaw : strtotime($ckDateRaw);
+      if (!$ts) {
+        $errors['ckDate'] = t('That is the wrong format for a date.');
+      } else {
+        $out['ckDate'] = $ts;
+      }
+    }
+  }
+
   return $out;
 }
 


### PR DESCRIPTION


> When the type of grant payment chosen is "check", the form needs to show two additional fields: check number and check date (which become part of the transaction description).

## Change

Extends `cgpayGrantsParseFlds()` in cgpaygrants.inc to accept `ckNum` and `ckDate` in the POST/PATCH body:

- **Required** when `by == "check"` (both fields must be present + valid)
- **Optional** when `by` is ach/wire (accepted if sent, ignored otherwise)
- `ckDate` accepts unix timestamps or any strtotime-parseable string; stored as int timestamp (matches the pattern in fsgrants.inc:92)

Per-field validation errors follow the same shape as the rest of the form ("Please enter the check number.", "That is the wrong format for a date.", etc.). The grants table already has `ckNum` (varchar) and `ckDate` (int) columns from FSGRANTS_FLDS - no schema change needed.

## Companion PR

Frontend UI to show the conditional fields when payment method is "check" lands in a separate cgpay PR. Both should merge together or the frontend will send fields the backend ignores (harmless) / backend will reject checks without them (fine, matches spec).